### PR TITLE
165 dont include sdk include in the public include fields of clib4

### DIFF
--- a/library/include/dos.h
+++ b/library/include/dos.h
@@ -14,6 +14,9 @@
 #include <wchar.h>
 #include <setjmp.h>
 #include <resolv.h>
+#include <exec/types.h>
+#include <exec/lists.h>
+#include <exec/semaphores.h>
 
 /* Category name handling variables.  */
 #define NUM_LOCALES                (LC_MAX + 1)

--- a/library/include/malloc.h
+++ b/library/include/malloc.h
@@ -9,8 +9,6 @@
 
 #include <stddef.h>
 #include <stdio.h>
-#include <exec/lists.h>
-#include <exec/nodes.h>
 
 #define SIZE_ALIGN (4 * sizeof(size_t))
 #define SIZE_MASK (-SIZE_ALIGN)

--- a/library/include/pthread.h
+++ b/library/include/pthread.h
@@ -26,8 +26,6 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <errno.h>
-#include <exec/types.h>
-#include <exec/semaphores.h>
 #include <sched.h>
 #include <features.h>
 
@@ -144,12 +142,7 @@ struct pthread_mutexattr {
 
 typedef struct pthread_mutexattr pthread_mutexattr_t;
 
-struct pthread_mutex {
-    APTR mutex;
-    int kind;
-    int incond;
-    struct Task *owner;
-};
+struct pthread_mutex;
 
 typedef struct pthread_mutex pthread_mutex_t;
 
@@ -173,11 +166,7 @@ struct pthread_condattr {
 
 typedef struct pthread_condattr pthread_condattr_t;
 
-struct pthread_cond {
-    int pad1;
-    struct SignalSemaphore semaphore;
-    struct MinList waiters;
-};
+struct pthread_cond;
 
 typedef struct pthread_cond pthread_cond_t;
 
@@ -195,12 +184,7 @@ struct pthread_barrierattr {
 
 typedef struct pthread_barrierattr pthread_barrierattr_t;
 
-struct pthread_barrier {
-    unsigned int curr_height;
-    unsigned int total_height;
-    pthread_cond_t breeched;
-    pthread_mutex_t lock;
-};
+struct pthread_barrier;
 
 typedef struct pthread_barrier pthread_barrier_t;
 
@@ -214,9 +198,7 @@ struct pthread_rwlockattr {
 
 typedef struct pthread_rwlockattr pthread_rwlockattr_t;
 
-struct pthread_rwlock {
-    struct SignalSemaphore semaphore;
-};
+struct pthread_rwlock;
 
 typedef struct pthread_rwlock pthread_rwlock_t;
 

--- a/library/include/semaphore.h
+++ b/library/include/semaphore.h
@@ -40,14 +40,7 @@
 #undef SEM_FAILED
 #define SEM_FAILED ((sem_t *)(-1))
 
-struct sema
-{
-    struct Node node;
-    int value;
-    int waiters_count;
-    pthread_mutex_t lock;
-    pthread_cond_t count_nonzero;
-};
+struct sema;
 
 typedef struct sema sem_t;
 

--- a/library/pthread/common.h
+++ b/library/pthread/common.h
@@ -6,6 +6,38 @@
 #include "pthread.h"
 #include <sys/time.h>
 
+struct pthread_mutex {
+    APTR mutex;
+    int kind;
+    int incond;
+    struct Task *owner;
+};
+
+struct pthread_cond {
+    int pad1;
+    struct SignalSemaphore semaphore;
+    struct MinList waiters;
+};
+
+struct pthread_barrier {
+    unsigned int curr_height;
+    unsigned int total_height;
+    pthread_cond_t breeched;
+    pthread_mutex_t lock;
+};
+
+struct pthread_rwlock {
+    struct SignalSemaphore semaphore;
+};
+
+struct sema {
+    struct Node node;
+    int value;
+    int waiters_count;
+    pthread_mutex_t lock;
+    pthread_cond_t count_nonzero;
+};
+
 #undef NEWLIST
 #define NEWLIST(_l)                                     \
 do                                                      \

--- a/library/rt/aio_misc.h
+++ b/library/rt/aio_misc.h
@@ -22,6 +22,7 @@
 #include <errno.h>
 #include <pthread.h>
 
+#include "../pthread/common.h"
 #include "clist.h"
 
 /* Used by aio functions */


### PR DESCRIPTION
Removed SDK includes from public header files:

 * `pthread.h`
 * `malloc.h`
 
Restructure implementation, to include none public structures, includes, etc