### PR TITLE
Release the attempted lock in the case of PTHREAD_MUTEX_ERRORCHECK. R…

### DIFF
--- a/library/pthread/pthread_mutex_lock.c
+++ b/library/pthread/pthread_mutex_lock.c
@@ -61,7 +61,9 @@ pthread_mutex_lock(pthread_mutex_t *mutex) {
         if (!isLocked) {
             SHOWMSG("DeadLock");
             return EDEADLK;
-        }
+        } else {
+	  MutexRelease(mutex->mutex);
+	}
     }
 
     SHOWMSG("MutexObtain");


### PR DESCRIPTION
…ather than just returning the lock we release and then continue to apply MutexObtain since that code does different things such as adding to the list of blockers in execsg

References: #182 