### PR TITLE
Merge Beta10 into master

### DIFF
--- a/library/dirent/opendir.c
+++ b/library/dirent/opendir.c
@@ -150,7 +150,7 @@ opendir(const char *path_name) {
         }
 
         dh->dh_Context = ObtainDirContextTags(EX_FileLockInput, dh->dh_DirLock,
-                                              EX_DoCurrentDir, TRUE,
+                                              EX_DoCurrentDir, FALSE,
                                               EX_DataFields, EXF_ALL,
                                               TAG_END);
         if (dh->dh_Context == NULL) {

--- a/library/include/time.h
+++ b/library/include/time.h
@@ -102,7 +102,7 @@ struct timespec64 {
   {                                                  \
     (result)->tv_sec = (a)->tv_sec + (b)->tv_sec;    \
     (result)->tv_usec = (a)->tv_usec + (b)->tv_usec; \
-    if ((int32) ((result)->tv_usec) >= 1000000)                \
+    if ((int32_t) ((result)->tv_usec) >= 1000000)                \
     {                                                \
       ++(result)->tv_sec;                            \
       (result)->tv_usec -= 1000000;                  \
@@ -113,7 +113,7 @@ struct timespec64 {
   {                                                  \
     (result)->tv_sec = (a)->tv_sec - (b)->tv_sec;    \
     (result)->tv_usec = (a)->tv_usec - (b)->tv_usec; \
-    if ((int32) ((result)->tv_usec) < 0)                       \
+    if ((int32_t) ((result)->tv_usec) < 0)                       \
     {                                                \
       --(result)->tv_sec;                            \
       (result)->tv_usec += 1000000;                  \
@@ -129,7 +129,7 @@ struct timespec64 {
   {                                                  \
     (result)->Seconds = (a)->Seconds + (b)->Seconds;    \
     (result)->Microseconds = (a)->Microseconds + (b)->Microseconds; \
-    if ((int32) ((result)->Microseconds) >= 1000000)                \
+    if ((int32_t) ((result)->Microseconds) >= 1000000)                \
     {                                                \
       ++(result)->Seconds;                            \
       (result)->Microseconds -= 1000000;                  \
@@ -140,7 +140,7 @@ struct timespec64 {
   {                                                  \
     (result)->Seconds = (a)->Seconds - (b)->Seconds;    \
     (result)->Microseconds = (a)->Microseconds - (b)->Microseconds; \
-    if ((int32) ((result)->Microseconds) < 0)                       \
+    if ((int32_t) ((result)->Microseconds) < 0)                       \
     {                                                \
       --(result)->Seconds;                            \
       (result)->Microseconds += 1000000;                  \


### PR DESCRIPTION
Release the attempted lock in the case of PTHREAD_MUTEX_ERRORCHECK  Rather than just returning the lock we release and then continue to apply MutexObtain since that code does different things such as adding to the list of blockers in execsg