### PR TITLE
Fixed Spawnv. Added waitpid/wait functions

### DIFF
--- a/libc.gmk
+++ b/libc.gmk
@@ -112,6 +112,7 @@ C_LOCALE := \
 	locale/setlocale.o
 
 C_MISC := \
+	misc/children.o \
 	misc/map.o \
 	misc/uuid.o
 

--- a/libc.gmk
+++ b/libc.gmk
@@ -196,6 +196,8 @@ C_POSIX := \
 	posix/sysv_shmids.o \
 	posix/ulimit.o \
 	posix/readv.o \
+	wait/wait.o \
+	wait/waitpid.o \
 	posix/writev.o \
 	posix/uname.o
 

--- a/library/getclib4.c
+++ b/library/getclib4.c
@@ -5,7 +5,6 @@
 #include <debug.h>
 
 #include "shared_library/clib4.h"
-#include "map.h"
 
 struct _clib4 *
 __getClib4(void) {

--- a/library/include/sys/wait.h
+++ b/library/include/sys/wait.h
@@ -16,6 +16,9 @@ __BEGIN_DECLS
 #define WTERMSIG(w)	((w) & 0x7f)
 #define WSTOPSIG	WEXITSTATUS
 
+pid_t wait(int *status);
+pid_t waitpid(pid_t pid, int *status, int options);
+
 __END_DECLS
 
 #endif

--- a/library/misc/children.c
+++ b/library/misc/children.c
@@ -5,23 +5,56 @@
 #include "clib4.h"
 #include "children.h"
 
+static void *
+gidChildrenScan(const void *children, void *gid) {
+    const struct Clib4Children *myChildren = children;
+    const int groupId = *((int *)gid);
+    if (myChildren->groupId == groupId)
+        return (struct Clib4Children *) children;
+    return NULL;
+}
+
+static void *
+pidChildrenScan(const void *children, void *pid) {
+    const struct Clib4Children *myChildren = children;
+    const int processId = *((int *)pid);
+    if (myChildren->pid == processId)
+        return (struct Clib4Children *) children;
+    return NULL;
+}
+
 BOOL
 insertSpawnedChildren(uint32 pid, uint32 gid) {
     DECLARE_UTILITYBASE();
 
     struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
     if (res) {
-        struct Clib4Children *children = AllocVecTags(sizeof(struct Clib4Children), AVT_Type, MEMF_SHARED, AVT_ClearWithValue, 0, TAG_DONE);
-        if (children) {
-            children->pid = pid;
-            children->returnCode = 0;
-            children->groupId = gid;
-            struct SplayNode *node = InsertSplayNode(res->spawnedProcesses, pid, sizeof(*children));
-            if (node) {
-                node->sn_UserData = children;
-                return TRUE;
-            }
-        }
+        struct Clib4Children children;
+        children.pid = pid;
+        children.returnCode = 0;
+        children.groupId = gid;
+        hashmap_set(res->spawnedProcesses, &children);
+        return TRUE;
     }
     return FALSE;
+}
+
+struct Clib4Children *
+findSpawnedChildrenByPid(uint32 pid) {
+    struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
+    if (res) {
+        return (struct Clib4Children *) hashmap_scan_item(res->spawnedProcesses, pidChildrenScan, &pid);
+    }
+    return NULL;
+}
+
+struct Clib4Children *
+findSpawnedChildrenByGid(uint32 pid, uint32 gid) {
+    struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
+    if (res) {
+        struct Clib4Children *children = hashmap_scan_item(res->spawnedProcesses, pidChildrenScan, &pid);
+        if (children->groupId == gid)
+            return children;
+    }
+    return NULL;
 }

--- a/library/misc/children.c
+++ b/library/misc/children.c
@@ -1,0 +1,27 @@
+#ifndef _UNISTD_HEADERS_H
+#include "unistd_headers.h"
+#endif /* _UNISTD_HEADERS_H */
+
+#include "clib4.h"
+#include "children.h"
+
+BOOL
+insertSpawnedChildren(uint32 pid, uint32 gid) {
+    DECLARE_UTILITYBASE();
+
+    struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
+    if (res) {
+        struct Clib4Children *children = AllocVecTags(sizeof(struct Clib4Children), AVT_Type, MEMF_SHARED, AVT_ClearWithValue, 0, TAG_DONE);
+        if (children) {
+            children->pid = pid;
+            children->returnCode = 0;
+            children->groupId = gid;
+            struct SplayNode *node = InsertSplayNode(res->spawnedProcesses, pid, sizeof(*children));
+            if (node) {
+                node->sn_UserData = children;
+                return TRUE;
+            }
+        }
+    }
+    return FALSE;
+}

--- a/library/misc/children.h
+++ b/library/misc/children.h
@@ -1,0 +1,10 @@
+#ifndef __CHILDREN_H__
+#define __CHILDREN_H_
+
+#ifndef _UNISTD_HEADERS_H
+#include "unistd_headers.h"
+#endif /* _UNISTD_HEADERS_H */
+
+BOOL insertSpawnedChildren(uint32 pid, uint32 gid);
+
+#endif

--- a/library/misc/children.h
+++ b/library/misc/children.h
@@ -5,6 +5,10 @@
 #include "unistd_headers.h"
 #endif /* _UNISTD_HEADERS_H */
 
+#include "clib4.h"
+
 BOOL insertSpawnedChildren(uint32 pid, uint32 gid);
+struct Clib4Children *findSpawnedChildrenByPid(uint32 pid);
+struct Clib4Children *findSpawnedChildrenByGid(uint32 pid, uint32 gid);
 
 #endif

--- a/library/posix/sysv_idkey.c
+++ b/library/posix/sysv_idkey.c
@@ -21,8 +21,8 @@ GetUndo(struct Clib4Resource *res, int id, int create) {
     struct Clib4Node key;
     memset(&key, 0, sizeof(struct Clib4Node));
     strncpy(key.uuid, __clib4->uuid, UUID4_LEN);
-    struct Clib4Node *c2n = hashmap_get(res->children, &key);
-    if (c2n->undo != NULL) {
+    struct Clib4Node *c2n = (struct Clib4Node *) hashmap_get(res->children, &key);
+    if (c2n != NULL && c2n->undo != NULL) {
         ui = c2n->undo;
         while (ui) {
             if (ui->Id == id) {

--- a/library/shared_library/clib4.c
+++ b/library/shared_library/clib4.c
@@ -202,6 +202,9 @@ struct Clib4Base *libOpen(struct LibraryManagerInterface *Self, uint32 version) 
         D(("c2n.uuid = %s", c2n.uuid));
         hashmap_set(res->children, &c2n);
 
+        /* Initialize processes hashmap */
+        res->spawnedProcesses = hashmap_new(sizeof(struct Clib4Children), 0, 0, 0, clib4IntHash, clib4ProcessCompare, NULL, NULL);
+
         switch (res->cpufamily) {
 #ifdef __SPE__
             case CPUFAMILY_E500:
@@ -306,9 +309,8 @@ BPTR libClose(struct LibraryManagerInterface *Self) {
                 break;
             }
         }
-        /* Remove spawnedProcess splay tree */
-        __IUtility->DeleteSplayTree(res->spawnedProcesses);
-        res->spawnedProcesses = NULL;
+        /* Remove spawnedProcess hashmap */
+        hashmap_free(res->spawnedProcesses);
     }
 
     --libBase->libNode.lib_OpenCnt;
@@ -382,6 +384,12 @@ unixSocketCompare(const void *a, const void *b, void *udata) {
 }
 
 uint64_t
+clib4IntHash(const void *item, uint64_t seed0, uint64_t seed1) {
+    return hashmap_xxhash3(item, sizeof(int), seed0, seed1);
+}
+
+
+uint64_t
 clib4NodeHash(const void *item, uint64_t seed0, uint64_t seed1) {
     const struct Clib4Node *node = item;
     return hashmap_xxhash3(node->uuid, strlen(node->uuid), seed0, seed1);
@@ -391,14 +399,14 @@ int
 clib4NodeCompare(const void *a, const void *b, void *udata) {
     const struct Clib4Node *ua = a;
     const struct Clib4Node *ub = b;
-    return ua->uuid == ub->uuid;
+    return strcmp(ua->uuid, ub->uuid);
 }
 
 int
 clib4ProcessCompare(const void *a, const void *b, void *udata) {
     const struct Clib4Children *ua = a;
     const struct Clib4Children *ub = b;
-    return ua->pid == ub->pid;
+    return ua->pid - ub->pid;
 }
 
 struct Clib4Base *libInit(struct Clib4Base *libBase, BPTR seglist, struct ExecIFace *const iexec) {
@@ -482,9 +490,6 @@ struct Clib4Base *libInit(struct Clib4Base *libBase, BPTR seglist, struct ExecIF
             res->children = hashmap_new(sizeof(struct Clib4Node), 0, 0, 0, clib4NodeHash, clib4NodeCompare, NULL, NULL);
             /* Initialize unix sockets hashmap */
             res->uxSocketsMap = hashmap_new(sizeof(struct UnixSocket), 0, 0, 0, unixSocketHash, unixSocketCompare, NULL, NULL);
-            /* Initialize processes SplayTree */
-            res->spawnedProcessesHook.h_Entry = (HOOKFUNC) clib4ProcessCompare;
-            res->spawnedProcesses = __IUtility->CreateSplayTree(&res->spawnedProcessesHook);
 
             /* Initialize fallback clib4 reent structure */
             res->fallbackClib = (struct _clib4 *) iexec->AllocVecTags(sizeof(struct _clib4),

--- a/library/shared_library/clib4.h
+++ b/library/shared_library/clib4.h
@@ -21,11 +21,13 @@ extern void _longjmp_spe(struct __jmp_buf_tag, int);
 extern int _setjmp_spe(struct __jmp_buf_tag);                                                                                                 /* 1796 */
 
 struct Clib4Resource {
-    struct Library          resource;       /* must be first */
-    uint32                  size;           /* for struct validation only */
-    struct SignalSemaphore  semaphore;      /* for list arbitration */
-    struct hashmap         *children;       /* list of parent nodes */
+    struct Library          resource;           /* must be first */
+    uint32                  size;               /* for struct validation only */
+    struct SignalSemaphore  semaphore;          /* for list arbitration */
+    struct hashmap         *children;           /* list of parent nodes */
     struct hashmap         *uxSocketsMap;
+    struct SplayTree       *spawnedProcesses;   /* list of spawned processes */
+    struct Hook             spawnedProcessesHook;
     struct _clib4          *fallbackClib;
     /* SysVIPC fields */
     int locked;
@@ -60,6 +62,12 @@ struct Clib4Base {
     struct Library libNode;
     uint16 pad;
     BPTR SegList;
+};
+
+struct Clib4Children {
+    uint32  pid;        /* the process PID */
+    uint32  returnCode; /* the return code of process */
+    gid_t   groupId;    /* Group ID of process */
 };
 
 int libReserved(void);

--- a/library/shared_library/clib4.h
+++ b/library/shared_library/clib4.h
@@ -26,8 +26,7 @@ struct Clib4Resource {
     struct SignalSemaphore  semaphore;          /* for list arbitration */
     struct hashmap         *children;           /* list of parent nodes */
     struct hashmap         *uxSocketsMap;
-    struct SplayTree       *spawnedProcesses;   /* list of spawned processes */
-    struct Hook             spawnedProcessesHook;
+    struct hashmap         *spawnedProcesses;   /* list of spawned processes */
     struct _clib4          *fallbackClib;
     /* SysVIPC fields */
     int locked;
@@ -66,8 +65,8 @@ struct Clib4Base {
 
 struct Clib4Children {
     uint32  pid;        /* the process PID */
-    uint32  returnCode; /* the return code of process */
     gid_t   groupId;    /* Group ID of process */
+    uint32  returnCode; /* the return code of process */
 };
 
 int libReserved(void);
@@ -76,6 +75,9 @@ uint32 libObtain(struct LibraryManagerInterface *Self);
 struct Clib4Base *libOpen(struct LibraryManagerInterface *Self, uint32 version);
 struct Clib4Base *libInit(struct Clib4Base *libBase, BPTR seglist, struct ExecIFace *const iexec);
 BPTR libExpunge(struct LibraryManagerInterface *Self);
+
+uint64_t clib4IntHash(const void *item, uint64_t seed0, uint64_t seed1);
+int clib4ProcessCompare(const void *a, const void *b, void *udata);
 
 static void _start_ctors(void (*__CTOR_LIST__[])(void));
 static void _start_dtors(void (*__DTOR_LIST__[])(void));

--- a/library/shared_library/clib4_vectors.h
+++ b/library/shared_library/clib4_vectors.h
@@ -1161,5 +1161,8 @@ static void *clib4Vectors[] = {
         (void *) (__get_daylight),                        /* 4352 */
         (void *) (__get_tzname),                          /* 4356 */
 
+        (void *) (wait),                                  /* 4360 */
+        (void *) (waitpid),                               /* 4364 */
+
         (void *)-1
 };

--- a/library/shared_library/interface.h
+++ b/library/shared_library/interface.h
@@ -81,6 +81,7 @@
 #include <sys/times.h>
 #include <sys/utsname.h>
 #include <sys/uio.h>
+#include <sys/wait.h>
 
 struct NameTranslationInfo;
 
@@ -1330,6 +1331,9 @@ struct Clib4IFace {
     int (* __get_timezone) (void);                                                                                                                   /* 4348 */
     int (*__get_daylight) (void);                                                                                                                    /* 4352 */
     char ** (* __get_tzname) (void);                                                                                                                 /* 4356 */
+
+    pid_t (* wait) (int *status);                                                                                                                    /* 4360 */
+    pid_t (* waitpid) (pid_t pid, int *status, int options);                                                                                         /* 4364 */
 
 };
 

--- a/library/shared_library/stubs.c
+++ b/library/shared_library/stubs.c
@@ -1100,3 +1100,6 @@ Clib4Call(__cxa_finalize, 4344);
 Clib4Call(__get_timezone, 4348);
 Clib4Call(__get_daylight, 4352);
 Clib4Call(__get_tzname, 4356);
+
+Clib4Call(wait, 4360);
+Clib4Call(waitpid, 4364);

--- a/library/unistd/spawnv.c
+++ b/library/unistd/spawnv.c
@@ -174,6 +174,7 @@ spawnv(int mode, const char *file, const char **argv) {
                      SYS_UserShell, TRUE,
                      SYS_Asynch, mode == P_WAIT ? FALSE : TRUE,
                      NP_Name, file,
+                     NP_Child, TRUE,
                      TAG_DONE);
 
     if (ret != 0) {
@@ -189,7 +190,12 @@ spawnv(int mode, const char *file, const char **argv) {
          */
         if (mode == P_NOWAIT) {
             ret = IoErr(); // This is our ProcessID;
-            insertSpawnedChildren(ret, getgid());
+            if (insertSpawnedChildren(ret, getgid())) {
+                D(("Children with pid %ld and gid %ld inserted into list\n", ret, getgid()));
+            }
+            else {
+                D(("Cannot insert children with pid %ld and gid %ld into list\n", ret, getgid()));
+            }
         }
     }
     return ret;

--- a/library/wait/wait.c
+++ b/library/wait/wait.c
@@ -9,5 +9,5 @@
 #include <sys/wait.h>
 
 pid_t wait(int *status) {
-    int32_t rc = WaitForChildExit(0);
+    return waitpid(-1, status, 0);
 }

--- a/library/wait/waitpid.c
+++ b/library/wait/waitpid.c
@@ -8,11 +8,125 @@
 
 #include <sys/wait.h>
 
+#include "clib4.h"
+
+static APTR
+hook_function(struct Hook *hook, APTR userdata, struct Process *process) {
+    uint32 pid = (uint32) userdata;
+    (void) (hook);
+
+    if (process->pr_ProcessID == pid) {
+        return process;
+    }
+
+    return 0;
+}
+
 pid_t waitpid(pid_t pid, int *status, int options) {
-    if (options != WNOHANG) {
+    Delay(1);
+
+    if (options != 0 && options != WNOHANG) {
         __set_errno(EINVAL);
         return -1;
     }
 
-    if (pid )
+    struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
+    if (res) {
+        struct Hook h = {{NULL, NULL}, (HOOKFUNC) hook_function, NULL, NULL};
+        int32 process;
+        size_t iter = 0;
+        void *item;
+
+        if (pid < -1) {
+            int gid = pid * -1;
+            while (hashmap_iter(res->spawnedProcesses, &iter, &item)) {
+                const struct Clib4Children *children = item;
+                if (children->groupId == gid) {
+                    process = ProcessScan(&h, (CONST_APTR) children->pid, 0);
+                    if (process == 0) {
+                        /* Remove process from spawnedProcess since it is not found anymore */
+                        *status = 0;
+                        hashmap_delete(res->spawnedProcesses, item);
+                        return children->pid;
+                    }
+                    if (options == 0) {
+                        WaitForChildExit(children->pid);
+                        *status = 0;
+                        hashmap_delete(res->spawnedProcesses, item);
+                        return children->pid;
+                    }
+                }
+            }
+            return 0;
+        } else if (pid == 0) {
+            while (hashmap_iter(res->spawnedProcesses, &iter, &item)) {
+                const struct Clib4Children *children = item;
+                process = ProcessScan(&h, (CONST_APTR) children->pid, 0);
+                if (process > 0) {
+                    if (options == 0) {
+                        WaitForChildExit(children->pid);
+                        *status = 0;
+                        hashmap_delete(res->spawnedProcesses, item);
+                        return children->pid;
+                    }
+                }
+                else {
+                    *status = 0;
+                    hashmap_delete(res->spawnedProcesses, item);
+                    return children->pid;
+                }
+            }
+            return 0;
+        } else {
+            D(("Searching for children with pid: %ld\n", pid));
+            struct Clib4Children key;
+            key.pid = pid;
+            struct Clib4Children *item = hashmap_get(res->spawnedProcesses, &key);
+            if (item != NULL) {
+                /* Scan for process */
+                process = ProcessScan(&h, (CONST_APTR) pid, 0);
+                D(("Children with pid %ld and process %ld found\n", pid, process));
+                if (process > 0) {
+                    if (options == 0) {
+                        D(("Wait on Child pid %ld\n", pid));
+                        WaitForChildExit(pid);
+                        D(("Children with pid %ld has died\n", pid));
+                        *status = 0;
+                        hashmap_delete(res->spawnedProcesses, item);
+                        return pid;
+                    }
+                    else {
+                        D(("Check for Child pid %ld\n", pid));
+                        int32 found = CheckForChildExit(item->pid);
+                        if (!found) {
+                            D(("Process with pid %ld not found. Most probably has died\n", pid));
+                            *status = 0;
+                            hashmap_delete(res->spawnedProcesses, item);
+                            return item->pid;
+                        }
+                        else {
+                            D(("Process with pid %ld still running\n", pid));
+                        }
+                    }
+                }
+                else {
+                    D(("Process with pid %ld not found. Most probably has died\n", pid));
+                    *status = 0;
+                    hashmap_delete(res->spawnedProcesses, item);
+                    return pid;
+                }
+            }
+            else {
+                *status = 0;
+                D(("Childred with pid %ld not found!\n", pid));
+                return item->pid;
+            }
+            *status = 0xFF;
+            return 0;
+        }
+    }
+    else {
+        __set_errno(EINVAL);
+        return -1;
+    }
 }

--- a/library/wait/waitpid.c
+++ b/library/wait/waitpid.c
@@ -1,0 +1,18 @@
+/*
+ * $Id: wait_wait.c,v 1.0 2023-06-09 12:04:27 clib4devs Exp $
+*/
+
+#ifndef _STDLIB_HEADERS_H
+#include "stdlib_headers.h"
+#endif /* _STDLIB_HEADERS_H */
+
+#include <sys/wait.h>
+
+pid_t waitpid(pid_t pid, int *status, int options) {
+    if (options != WNOHANG) {
+        __set_errno(EINVAL);
+        return -1;
+    }
+
+    if (pid )
+}

--- a/test_programs/misc/spawnv_async.c
+++ b/test_programs/misc/spawnv_async.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <unistd.h>
+
+int main(int argc, const char *argv[]) {
+
+    if (argc < 2) {
+        printf("Usage: spawnv_async <command>\n");
+        return 1;
+    }
+    int pid = spawnv(P_NOWAIT, argv[1], &argv[1]);
+    if (pid )
+    printf("spawnv PID %d\n", pid);
+
+    return 0;
+}

--- a/test_programs/misc/waitpid.c
+++ b/test_programs/misc/waitpid.c
@@ -1,0 +1,33 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <unistd.h>
+#include <sys/wait.h>
+
+int main(int argc, char *argv[]) {
+    pid_t pid;
+    int status;
+
+    if (argc < 2) {
+        printf("Usage: waitpid <command>\n");
+        return 1;
+    }
+    printf("Run command: %s\n", argv[1]);
+    pid = spawnv(P_NOWAIT, argv[1], (const char **) &argv[1]);
+    if (pid > 0) {
+        printf("Child pid: %i\n", pid);
+        do {
+            int ret = waitpid(pid, &status, 0);
+            printf("waitpid ret = %d\n", ret);
+            if (ret != -1) {
+                printf("Child status %d\n", WEXITSTATUS(status));
+            } else {
+                perror("waitpid");
+                break;
+            }
+        } while (!WIFEXITED(status) && !WIFSIGNALED(status));
+    } else {
+        printf("posix_spawn: %s\n", strerror(status));
+    }
+}


### PR DESCRIPTION
Fixed Spawnv. Added waitpid/wait functions
However waitpid needs to be tested deeply.
There is an example program you could run using for example with `waitpid notepad t:usb.log` and wait for exit
The program has been tested with bot 0 and WNOHANG as parameters.
Spawnv now return pid correctly if executed with P_NOWAIT