### PR TITLE
Further patches on the unix->amiga path translation algorithm

### DIFF
--- a/library/unistd/translateu2a.c
+++ b/library/unistd/translateu2a.c
@@ -115,10 +115,28 @@ __translate_unix_to_amiga_path_name(char const **name_ptr, struct name_translati
             name = home_dir_name;
         } else {
             
+#if 0
             /* If input string is a command, we can use the system path to expand.
                This should not conflict with previous implements, because the only
                diverging situation is where it would previously return a non-existing
                path to the current directory. */
+
+            /* Response : This is not true. In cases, where the application is trying
+                to determine if an object in the current dir exists, it can potentially
+                give the wrong answer, if an object with immediate address on the 
+                search path exists. For instance:
+                
+                Current dir : /work/foo
+                stat on : bar
+                On path: bar
+
+                This can possibly result in a stat returning the address
+
+                    /work/foo/bar
+
+                which doesn't exist (awennermark).
+            */
+
             if(strchr(name, '/') == NULL) {
                 if(__search_expand_command_path((const char **) &name, nti->substitute, sizeof(nti->substitute)) == 0) {
                     SHOWMSG("Successfully expanded command string using system paths.\n");
@@ -130,14 +148,24 @@ __translate_unix_to_amiga_path_name(char const **name_ptr, struct name_translati
                 }
             }
         }
+#endif
 
+#if 0
         /* Prepend an absolute path to the name, if such a path was previously set
            as the current directory. */
+
+        /* Response : This is not good. We might be dealing with a command name (as in popen),
+            which means, that the tagging-on of any path (cwd or otherwise) to the command
+            name could potentially break the call. Even if this leaves the result of this call
+            with a non-absolute path, it will still work, in case the sought-after object is in fact
+            found in the current directory. So there are no benefits in tagging on the current
+            path - it will not add anything to the functionality of the enterprise. (awennermark) */
+
         if (__translate_relative_path_name((const char **) &name, nti->substitute, sizeof(nti->substitute)) < 0) {
             SHOWMSG("relative path name could not be worked into the pattern");
             goto out;
         }
-
+#endif
         /* If we wound up with the expanded home directory name,
            put it into the substitution string. */
         if (name == home_dir_name) {


### PR DESCRIPTION
1) Roll back the snip that introduces default (native) path search for unix->amiga path translation, because it can break the resulting program in cases, where such an object exists on the system path but not in the current dir. (stat(EXISTS) will return true in such cases, when the correct answer is false.

2) Comment out/suggest removal of the snip, that tags on the current path to an immediate (no-path) object in unix->amiga path translation, because of a parallel and very opposite case : If the program is trying to execute a command on the system search path, this snip will tag on code, that makes it impossible for the call (for instance popen) to find the command.