### PR TITLE
Beta10 - spawnvpe contributions

### DIFF
--- a/library/c.lib_rev.h
+++ b/library/c.lib_rev.h
@@ -2,7 +2,7 @@
 #define REVISION		0
 #define SUBREVISION		0
 
-#define DATE			"26.07.2024"
+#define DATE			"29.07.2024"
 #define VERS			"clib4.library 1.0.0"
-#define VSTRING			"clib4.library 1.0.0 (26.07.2024)\r\n"
-#define VERSTAG			"\0$VER: clib4.library 1.0.0 (26.07.2024)"
+#define VSTRING			"clib4.library 1.0.0 (29.07.2024)\r\n"
+#define VERSTAG			"\0$VER: clib4.library 1.0.0 (29.07.2024)"

--- a/library/unistd/spawnvpe.c
+++ b/library/unistd/spawnvpe.c
@@ -122,7 +122,7 @@ spawnvpe_callback(
     const char *file,
     const char **argv,
     char **deltaenv,
-    const char *dir,
+    const char *cwd,
     int fhin,
     int fhout,
     int fherr,
@@ -163,6 +163,8 @@ spawnvpe_callback(
         progdirLock = ParentDir(fileLock);
         UnLock(fileLock);
     }
+
+    BPTR cwdLock = cwd ? Lock(cwd, SHARED_LOCK) : 0;
 
     parameter_string_len = get_arg_string_length((char *const *) argv);
     if (parameter_string_len > _POSIX_ARG_MAX) {
@@ -252,11 +254,13 @@ spawnvpe_callback(
                      SYS_Asynch, TRUE,
                      NP_Child, TRUE,
                      progdirLock ? NP_ProgramDir : TAG_SKIP, progdirLock,
+                     cwdLock ? NP_CurrentDir : TAG_SKIP, cwdLock,
                      NP_Name, strdup(processName),
                      entry_fp ? NP_EntryCode    : TAG_SKIP,	entry_fp,
                      entry_data ? NP_EntryData  : TAG_SKIP, entry_data,
                      final_fp ? NP_FinalCode    : TAG_SKIP,	final_fp,
                      final_data ? NP_FinalData  : TAG_SKIP, final_data,
+                     NP_ExitCode, spawnedProcessExit,
                      TAG_DONE);
 
     D(("SystemTags completed. return value: [%ld]\n", ret));


### PR DESCRIPTION
Do the following in spawnvpe :

1) Translate the cwd path parameter from unix to amiga path semantics.
2) Supply a lock on cwd as NP_CurrentDir for SystemTags.
3) Call spawnedProcessExit as NP_ExitCode for SystemTags.