### PR TITLE
Remove unneeded assertion in getcwd, because are valid input parameter

### DIFF
--- a/library/stat/fstat.c
+++ b/library/stat/fstat.c
@@ -32,15 +32,13 @@ fstat(int file_descriptor, struct stat *buffer) {
         goto out;
     }
 
-    assert(file_descriptor >= 0 && file_descriptor < __clib4->__num_fd);
-    assert(__clib4->__fd[file_descriptor] != NULL);
-    assert(FLAG_IS_SET(__clib4->__fd[file_descriptor]->fd_Flags, FDF_IN_USE));
-
     fd = __get_file_descriptor(__clib4, file_descriptor);
     if (fd == NULL) {
         __set_errno_r(__clib4, EBADF);
         goto out;
     }
+
+    assert(FLAG_IS_SET(__clib4->__fd[file_descriptor]->fd_Flags, FDF_IN_USE));
 
     __fd_lock(fd);
 

--- a/library/unistd/getcwd.c
+++ b/library/unistd/getcwd.c
@@ -26,10 +26,7 @@ getcwd(char *buffer, size_t buffer_size) {
     SHOWPOINTER(buffer);
     SHOWVALUE(buffer_size);
 
-    assert(buffer != NULL);
-    assert((int) buffer_size > 0);
-
-    __check_abort_f(__clib4);
+	__check_abort_f(__clib4);
 
     if (buffer_size == 0 || buffer == NULL) {
         /* As an extension to the POSIX.1-2001 standard, glibc's getcwd()


### PR DESCRIPTION
, because the assertion avoids the calling the function with valid parameters as described in an extension to the POSIX.1-2001 standard: glibc's getcwd() allocates the buffer dynamically using malloc(3) if buf is NULL. In this case, the allocated buffer has the length size unless size is zero, when buf is allocated as big as necessary.  