### PR TITLE
Added sigsuspend

### DIFF
--- a/libc.gmk
+++ b/libc.gmk
@@ -172,6 +172,7 @@ C_POSIX := \
 	posix/sigmask.o \
 	posix/signal.o \
 	posix/sigprocmask.o \
+	posix/sigsuspend.o \
 	posix/sigsetmask.o \
 	posix/statvfs.o \
 	posix/sysinfo.o \

--- a/library/include/signal.h
+++ b/library/include/signal.h
@@ -83,6 +83,7 @@ extern int sigmask(int signum);
 extern int sigblock(int signal_mask);
 extern int sigsetmask(int signal_mask);
 extern int sigprocmask(int how, const sigset_t *set, sigset_t *oset);
+extern int sigsuspend(const sigset_t *mask);
 extern int sigismember(const sigset_t *set, int sig);
 extern int sigemptyset(sigset_t *set);
 extern int sigfillset(sigset_t *set);

--- a/library/posix/sigsuspend.c
+++ b/library/posix/sigsuspend.c
@@ -1,0 +1,46 @@
+/*
+ * $Id: signal_sigsuspend.c $
+*/
+
+#ifndef _SIGNAL_HEADERS_H
+#include "signal_headers.h"
+#endif /* _SIGNAL_HEADERS_H */
+
+int
+sigsuspend(const sigset_t *mask) {
+    int result = ERROR;
+	sigset_t omask;
+    struct _clib4 *__clib4 = __CLIB4;
+
+    ENTER();
+
+    SHOWPOINTER(mask);
+
+    if (mask == NULL ) {
+        SHOWMSG("mask pointer is NULL");
+
+        __set_errno_r(__clib4, EINVAL);
+        goto out;
+    }
+
+	if (sigprocmask(SIG_SETMASK, mask, &omask) < 0) {
+        goto out;
+	}
+
+	pause();
+  	result = errno;
+  
+  	if (sigprocmask (SIG_SETMASK, &omask, (sigset_t *)NULL) < 0 ) {
+        goto out;
+	}
+
+	__set_errno_r(__clib4, result);
+
+out:
+
+    SHOWVALUE(result);
+	
+	LEAVE();
+
+    return -1 ;
+}

--- a/library/shared_library/clib4_vectors.h
+++ b/library/shared_library/clib4_vectors.h
@@ -1174,5 +1174,7 @@ static void *clib4Vectors[] = {
 
         (void *) (spawnvpe_callback),                     /* 4392 */
 
+        (void *) (sigsuspend),		                      /* 4396 */
+
         (void *)-1
 };

--- a/library/shared_library/interface.h
+++ b/library/shared_library/interface.h
@@ -607,7 +607,6 @@ struct Clib4IFace {
     int (* sigblock) (int signal_mask);                                                                                                              /* 1828 */
     int (* sigsetmask) (int signal_mask);                                                                                                            /* 1832 */
     int (* sigprocmask) (int how, const sigset_t *set, sigset_t *oset);                                                                              /* 1836 */
-    int (* sigsuspend) (const sigset_t *mask);		                                                                              					 /* 1837 */
     int (* sigismember) (const sigset_t *set, int sig);                                                                                              /* 1840 */
     int (* sigemptyset) (sigset_t *set);                                                                                                             /* 1844 */
     int (* sigfillset) (sigset_t *set);                                                                                                              /* 1848 */
@@ -1346,6 +1345,7 @@ struct Clib4IFace {
 
     int ( *spawnvpe_callback) (const char *file, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr, void (*entry_fp)(void *), void* entry_data, void (*final_fp)(int, void *), void* final_data);     /* 4392 */
 
+    int (* sigsuspend) (const sigset_t *mask);		                                                                              					 /* 4396 */
 };
 
 #ifdef __PIC__

--- a/library/shared_library/interface.h
+++ b/library/shared_library/interface.h
@@ -607,6 +607,7 @@ struct Clib4IFace {
     int (* sigblock) (int signal_mask);                                                                                                              /* 1828 */
     int (* sigsetmask) (int signal_mask);                                                                                                            /* 1832 */
     int (* sigprocmask) (int how, const sigset_t *set, sigset_t *oset);                                                                              /* 1836 */
+    int (* sigsuspend) (const sigset_t *mask);		                                                                              					 /* 1837 */
     int (* sigismember) (const sigset_t *set, int sig);                                                                                              /* 1840 */
     int (* sigemptyset) (sigset_t *set);                                                                                                             /* 1844 */
     int (* sigfillset) (sigset_t *set);                                                                                                              /* 1848 */

--- a/library/shared_library/stubs.c
+++ b/library/shared_library/stubs.c
@@ -457,6 +457,7 @@ Clib4Call(sigmask, 1824);
 Clib4Call(sigblock, 1828);
 Clib4Call(sigsetmask, 1832);
 Clib4Call(sigprocmask, 1836);
+Clib4Call(sigsuspend, 1837);
 Clib4Call(sigismember, 1840);
 Clib4Call(sigemptyset, 1844);
 Clib4Call(sigfillset, 1848);

--- a/library/shared_library/stubs.c
+++ b/library/shared_library/stubs.c
@@ -457,7 +457,6 @@ Clib4Call(sigmask, 1824);
 Clib4Call(sigblock, 1828);
 Clib4Call(sigsetmask, 1832);
 Clib4Call(sigprocmask, 1836);
-Clib4Call(sigsuspend, 1837);
 Clib4Call(sigismember, 1840);
 Clib4Call(sigemptyset, 1844);
 Clib4Call(sigfillset, 1848);
@@ -1114,3 +1113,5 @@ Clib4Call(__get_tc_up, 4384);
 Clib4Call(__get_tc_bc, 4388);
 
 Clib4Call(spawnvpe_callback, 4392);
+
+Clib4Call(sigsuspend, 4396);

--- a/test_programs/signal/suspend.c
+++ b/test_programs/signal/suspend.c
@@ -1,0 +1,15 @@
+#include <signal.h>
+
+int
+main ()
+{
+    sigset_t ss;
+    struct sigaction sa;
+    
+	sigemptyset(&ss);
+	sigsuspend(&ss);
+    sigaction(SIGINT, &sa, (struct sigaction *) 0);
+    sigprocmask(SIG_BLOCK, &ss, (sigset_t *) 0);
+	
+	return 0;
+}


### PR DESCRIPTION
Because `./configure` uses that method to detect if the target system is posix compatible. Hence having this method makes porting a bit less of a hassle. No need to manually add `-DHAVE_POSIX` to the compile flags.