### PR TITLE
Beta10 - patches to fix performance of spawnvpe+waitpid

### DIFF
--- a/library/c.lib_rev.h
+++ b/library/c.lib_rev.h
@@ -2,7 +2,7 @@
 #define REVISION		0
 #define SUBREVISION		0
 
-#define DATE			"11.08.2024"
+#define DATE			"27.08.2024"
 #define VERS			"clib4.library 1.0.0"
-#define VSTRING			"clib4.library 1.0.0 (11.08.2024)\r\n"
-#define VERSTAG			"\0$VER: clib4.library 1.0.0 (11.08.2024)"
+#define VSTRING			"clib4.library 1.0.0 (27.08.2024)\r\n"
+#define VERSTAG			"\0$VER: clib4.library 1.0.0 (27.08.2024)"

--- a/library/include/sys/wait.h
+++ b/library/include/sys/wait.h
@@ -12,7 +12,7 @@ __BEGIN_DECLS
 #define WIFEXITED(w)	(((w) & 0xff) == 0)
 #define WIFSIGNALED(w)	(((w) & 0x7f) > 0 && (((w) & 0x7f) < 0x7f))
 #define WIFSTOPPED(w)	(((w) & 0xff) == 0x7f)
-#define WEXITSTATUS(w)	(((w) >> 8) & 0xff)
+#define WEXITSTATUS(w)	(((w)) & 0x000000ff)
 #define WTERMSIG(w)	((w) & 0x7f)
 #define WSTOPSIG	WEXITSTATUS
 

--- a/library/include/unistd.h
+++ b/library/include/unistd.h
@@ -116,7 +116,6 @@ extern int spawnve(int mode, const char *path, const char **argv, char * const e
 extern int spawnvp(int mode, const char *path, const char **argv);
 /* Non standard. Used to help linux ports */
 extern int spawnvpe(const char *file, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr);
-// extern int spawnvpe_callback(const char *file, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr, void (*entry_fp)(void *), void* entry_data, void (*final_fp)(int, void *), void* final_data);
 
 extern int profil(unsigned short *buffer, size_t bufSize, size_t offset, unsigned int scale);
 extern long sysconf(int name);

--- a/library/include/unistd.h
+++ b/library/include/unistd.h
@@ -116,7 +116,7 @@ extern int spawnve(int mode, const char *path, const char **argv, char * const e
 extern int spawnvp(int mode, const char *path, const char **argv);
 /* Non standard. Used to help linux ports */
 extern int spawnvpe(const char *file, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr);
-extern int spawnvpe_callback(const char *file, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr, void (*entry_fp)(void *), void* entry_data, void (*final_fp)(int, void *), void* final_data);
+// extern int spawnvpe_callback(const char *file, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr, void (*entry_fp)(void *), void* entry_data, void (*final_fp)(int, void *), void* final_data);
 
 extern int profil(unsigned short *buffer, size_t bufSize, size_t offset, unsigned int scale);
 extern long sysconf(int name);

--- a/library/misc/children.c
+++ b/library/misc/children.c
@@ -126,21 +126,22 @@ void
 spawnedProcessExit(int32 rc, int32 data UNUSED) {
     struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
     if (res) {
+        int32 parent = GetPID(0, GPID_PARENT);
         int32 me = GetPID(0, GPID_PROCESS);
         size_t iter = 0;
         void *item;
 
         while (hashmap_iter(res->children, &iter, &item)) {
             const struct Clib4Node *node = item;
-            if (node->pid == me) {
+            if (node->pid == parent) {
                 struct Clib4Children key;
                 key.pid = me;
                 struct Clib4Children *item = (struct Clib4Children *) hashmap_get(node->spawnedProcesses, &key);
                 if (item != NULL) {
+                    DebugPrintF("[spawneeExit :] SUCCESS.\n");
                     item->returnCode = rc;
                 }
             }
         }
     }
 }
-

--- a/library/misc/children.c
+++ b/library/misc/children.c
@@ -33,7 +33,7 @@ insertSpawnedChildren(uint32 pid, uint32 gid) {
 
     struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
     if (res) {
-        uint32 me = GetPID(0, GPID_PROCESS);
+        uint32 parent = GetPID(0, GPID_PARENT);
         size_t iter = 0;
         void *item;
 
@@ -44,7 +44,7 @@ insertSpawnedChildren(uint32 pid, uint32 gid) {
 
         while (hashmap_iter(res->children, &iter, &item)) {
             const struct Clib4Node *node = item;
-            if (node->pid == me) {
+            if (node->pid == parent) {
                 hashmap_set(node->spawnedProcesses, &children);
                 break;
             }

--- a/library/misc/uuid.c
+++ b/library/misc/uuid.c
@@ -18,12 +18,20 @@ static uint64_t xorshift128plus(uint64_t *s) {
     return s[1] + s0;
 }
 
-void uuid4_generate(char *dst) {
+extern struct TimerIFace *ITimer;
+
+void uuid4_generate(char *_dst) {
+    char *dst = _dst;
     static const char *template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";
     static const char *chars = "0123456789abcdef";
     uint64_t seed[2] = {0, 0};
     struct RandomState state;
     DECLARE_UTILITYBASE();
+    // DECLARE_TIMERBASE();
+
+
+
+    GetSysTime((struct TimeVal *)&state);
 
     typedef union {
         int64_t big;
@@ -70,4 +78,6 @@ void uuid4_generate(char *dst) {
         dst++, p++;
     }
     *dst = '\0';
+
+    DebugPrintF("[uuid4_generate :] result : <%s>\n", _dst);
 }

--- a/library/shared_library/clib4_vectors.h
+++ b/library/shared_library/clib4_vectors.h
@@ -1172,7 +1172,7 @@ static void *clib4Vectors[] = {
         (void *) (__get_tc_up),                           /* 4384 */
         (void *) (__get_tc_bc),                           /* 4388 */
 
-        (void *) (spawnvpe_callback),                     /* 4392 */
+        (void *) (0),                     /* 4392 */
 
         (void *) (sigsuspend),		                      /* 4396 */
         (void *) (spawnve),                               /* 4400 */

--- a/library/shared_library/interface.h
+++ b/library/shared_library/interface.h
@@ -1343,7 +1343,7 @@ struct Clib4IFace {
     char * (* __get_tc_up) (void);                                                                                                                   /* 4384 */
     char * (* __get_tc_bc) (void);                                                                                                                   /* 4388 */
 
-    int ( *spawnvpe_callback) (const char *file, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr, void (*entry_fp)(void *), void* entry_data, void (*final_fp)(int, void *), void* final_data);     /* 4392 */
+    int ( *spawnvpe_callback_UNUSED) (const char *file, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr, void (*entry_fp)(void *), void* entry_data, void (*final_fp)(int, void *), void* final_data);     /* 4392 */
 
     int (* sigsuspend) (const sigset_t *mask);		                                                                              					 /* 4396 */
     int (* spawnve) (const char *path, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr);                         /* 4400 */

--- a/library/shared_library/stubs.c
+++ b/library/shared_library/stubs.c
@@ -1112,7 +1112,7 @@ Clib4Call(__get_tc_ospeed, 4380);
 Clib4Call(__get_tc_up, 4384);
 Clib4Call(__get_tc_bc, 4388);
 
-Clib4Call(spawnvpe_callback, 4392);
+// Clib4Call(spawnvpe_callback_UNUSED, 4392);
 
 Clib4Call(sigsuspend, 4396);
 Clib4Call(spawnve, 4400);

--- a/library/unistd/spawnvpe.c
+++ b/library/unistd/spawnvpe.c
@@ -146,7 +146,7 @@ spawnvpe(
     __set_errno(0);
 
     D(("Starting new process [%s]\n", name));
-    printf("[spawnvpe :] Starting new process [%s]\n", name);
+    // printf("[spawnvpe :] Starting new process [%s]\n", name);
 
     int error = __translate_unix_to_amiga_path_name(&name, &nti_name);
     if (error) {
@@ -205,7 +205,7 @@ spawnvpe(
 
     D(("File to execute: [%s]\n", finalpath));
 
-    printf("[spawnvpe :] full command == <%s>\n", finalpath);
+    // printf("[spawnvpe :] full command == <%s>\n", finalpath);
 
     if (fhin >= 0) {
         err = __get_default_file(fhin, &fh);

--- a/library/unistd/spawnvpe.c
+++ b/library/unistd/spawnvpe.c
@@ -334,19 +334,3 @@ spawnvpe(
     }
     return ret;
 }
-int
-spawnvpe_callback(
-    const char *file,
-    const char **argv,
-    char **deltaenv,
-    const char *cwd,
-    int fhin,
-    int fhout,
-    int fherr,
-
-    void (*entry_fp)(void *), void* entry_data,
-    void (*final_fp)(int, void *), void* final_data
-) {
-    __set_errno(EINVAL);
-    return -1;
-}

--- a/library/unistd/spawnvpe.c
+++ b/library/unistd/spawnvpe.c
@@ -117,30 +117,40 @@ get_arg_string_length(char *const argv[]) {
 
     return (result);
 }
-void spawnvpe_entryCode(int32 _ed);
-struct EntryData {
-    int8 signal;
-};
-void
-spawnvpe_entryCode(int32 _ed) {
-    struct EntryData *ed = (struct EntryData *)_ed;
-    ed->signal = AllocSignal(-1);
-    Wait(1 << ed->signal);
-    //this is to prevent, that the child is gone, when we do our registrations
-    FreeSignal(ed->signal);
-}
+// void spawnvpe_entryCode(int32 _ed);
+// struct EntryData {
+//     int8 signal;
+// };
+// void
+// spawnvpe_entryCode(int32 _ed) {
+//     struct EntryData *ed = (struct EntryData *)_ed;
+//     ed->signal = AllocSignal(-1);
+//     Wait(1 << ed->signal);
+//     //this is to prevent, that the child is gone, when we do our registrations
+//     FreeSignal(ed->signal);
+// }
+// int
+// spawnvpe_callback(
+//     const char *file,
+//     const char **argv,
+//     char **deltaenv,
+//     const char *cwd,
+//     int fhin,
+//     int fhout,
+//     int fherr,
+
+//     void (*entry_fp)(void *), void* entry_data,
+//     void (*final_fp)(int, void *), void* final_data
+// ) {
 int
-spawnvpe_callback(
+spawnvpe(
     const char *file,
     const char **argv,
     char **deltaenv,
     const char *cwd,
     int fhin,
     int fhout,
-    int fherr,
-
-    void (*entry_fp)(void *), void* entry_data,
-    void (*final_fp)(int, void *), void* final_data
+    int fherr
 ) {
     int ret = -1;
     struct name_translation_info nti_name;
@@ -172,9 +182,11 @@ spawnvpe_callback(
 
     D(("name after conversion: [%s]\n", name));
 
+#if 0
     seglist = LoadSeg(name);
 	if (!seglist)
 		return -1;
+#endif
 
     BPTR fileLock = Lock(name, SHARED_LOCK);
     if (fileLock) {
@@ -264,10 +276,10 @@ spawnvpe_callback(
 
     D(("(*)Calling SystemTags.\n"));
 
-    struct EntryData ed;
+    // struct EntryData ed;
 
     struct Task *_me = FindTask(0);
-#if 1
+#if 0
   struct Process *p = CreateNewProcTags(
     NP_Seglist,		seglist,
     NP_FreeSeglist,	TRUE,
@@ -348,35 +360,53 @@ spawnvpe_callback(
          * If mode is set as P_NOWAIT we can retrieve process id calling IoErr()
          * just after SystemTags. In this case spawnv will return pid
          */
-        ret = GetPID(p, GPID_PROCESS);
-        printf("[spawnvpe :] adding child entry with pid == %d\n", ret);
+        ret = IoErr();
 
-        // ret = IoErr();
-        if (insertSpawnedChildren(ret, getgid())) {
-            D(("Children with pid %ld and gid %ld inserted into list\n", ret, getgid()));
-        }
-        else {
-            D(("Cannot insert children with pid %ld and gid %ld into list\n", ret, getgid()));
-        }
+        // ret = GetPID(p, GPID_PROCESS);
+        // printf("[spawnvpe :] adding child entry with pid == %d\n", ret);
+
+        // if (insertSpawnedChildren(ret, getgid())) {
+        //     D(("Children with pid %ld and gid %ld inserted into list\n", ret, getgid()));
+        // }
+        // else {
+        //     D(("Cannot insert children with pid %ld and gid %ld into list\n", ret, getgid()));
+        // }
 
         //debug
-        struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
-        if (res) {
-            printf("[spawnvpe : ] Checking result after insertion...\n");
-            size_t childrenIter = 0;
-            void *childItem;
-            while (hashmap_iter(res->children, &childrenIter, &childItem)) {
-                const struct Clib4Node *node = childItem;
+        // struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
+        // if (res) {
+        //     printf("[spawnvpe : ] Checking result after insertion...\n");
+        //     size_t childrenIter = 0;
+        //     void *childItem;
+        //     while (hashmap_iter(res->children, &childrenIter, &childItem)) {
+        //         const struct Clib4Node *node = childItem;
 
-                printf("[waitpid :] iterating *** pid == %d\n", node->pid);
-            }
-        }
+        //         printf("[waitpid :] iterating *** pid == %d\n", node->pid);
+        //     }
+        // }
 
-        Signal((struct Task *)p, 1 << ed.signal); //let the child free
+        // Signal((struct Task *)p, 1 << ed.signal); //let the child free
     }
 
     return ret;
 }
-int spawnvpe(const char *file, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr) {
-    return spawnvpe_callback(file, argv, deltaenv, dir, fhin, fhout, fherr, 0, 0, 0, 0);
+// int spawnvpe(const char *file, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr) {
+//     return spawnvpe_callback(file, argv, deltaenv, dir, fhin, fhout, fherr, 0, 0, 0, 0);
+// }
+
+int
+spawnvpe_callback(
+    const char *file,
+    const char **argv,
+    char **deltaenv,
+    const char *cwd,
+    int fhin,
+    int fhout,
+    int fherr,
+
+    void (*entry_fp)(void *), void* entry_data,
+    void (*final_fp)(int, void *), void* final_data
+) {
+    __set_errno(EINVAL);
+    return -1;
 }

--- a/library/unistd/spawnvpe.c
+++ b/library/unistd/spawnvpe.c
@@ -117,31 +117,6 @@ get_arg_string_length(char *const argv[]) {
 
     return (result);
 }
-// void spawnvpe_entryCode(int32 _ed);
-// struct EntryData {
-//     int8 signal;
-// };
-// void
-// spawnvpe_entryCode(int32 _ed) {
-//     struct EntryData *ed = (struct EntryData *)_ed;
-//     ed->signal = AllocSignal(-1);
-//     Wait(1 << ed->signal);
-//     //this is to prevent, that the child is gone, when we do our registrations
-//     FreeSignal(ed->signal);
-// }
-// int
-// spawnvpe_callback(
-//     const char *file,
-//     const char **argv,
-//     char **deltaenv,
-//     const char *cwd,
-//     int fhin,
-//     int fhout,
-//     int fherr,
-
-//     void (*entry_fp)(void *), void* entry_data,
-//     void (*final_fp)(int, void *), void* final_data
-// ) {
 int
 spawnvpe(
     const char *file,
@@ -333,11 +308,6 @@ spawnvpe(
                      cwdLock ? NP_CurrentDir : TAG_SKIP, cwdLock,
                      NP_Name, strdup(processName),
 
-                    //  entry_fp ? NP_EntryCode    : TAG_SKIP,	entry_fp,
-                    //  entry_data ? NP_EntryData  : TAG_SKIP, entry_data,
-                    //  final_fp ? NP_FinalCode    : TAG_SKIP,	final_fp,
-                    //  final_data ? NP_FinalData  : TAG_SKIP, final_data,
-
                      NP_EntryCode,  spawnedProcessEnter,
                      NP_ExitCode,   spawnedProcessExit,
 
@@ -361,39 +331,9 @@ spawnvpe(
          * just after SystemTags. In this case spawnv will return pid
          */
         ret = IoErr();
-
-        // ret = GetPID(p, GPID_PROCESS);
-        // printf("[spawnvpe :] adding child entry with pid == %d\n", ret);
-
-        // if (insertSpawnedChildren(ret, getgid())) {
-        //     D(("Children with pid %ld and gid %ld inserted into list\n", ret, getgid()));
-        // }
-        // else {
-        //     D(("Cannot insert children with pid %ld and gid %ld into list\n", ret, getgid()));
-        // }
-
-        //debug
-        // struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
-        // if (res) {
-        //     printf("[spawnvpe : ] Checking result after insertion...\n");
-        //     size_t childrenIter = 0;
-        //     void *childItem;
-        //     while (hashmap_iter(res->children, &childrenIter, &childItem)) {
-        //         const struct Clib4Node *node = childItem;
-
-        //         printf("[waitpid :] iterating *** pid == %d\n", node->pid);
-        //     }
-        // }
-
-        // Signal((struct Task *)p, 1 << ed.signal); //let the child free
     }
-
     return ret;
 }
-// int spawnvpe(const char *file, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr) {
-//     return spawnvpe_callback(file, argv, deltaenv, dir, fhin, fhout, fherr, 0, 0, 0, 0);
-// }
-
 int
 spawnvpe_callback(
     const char *file,


### PR DESCRIPTION
There were different mistakes in the code, making it impossible for waitpid to find the return code element in the children hashmap.

1) uuid4_generate would not properly seed the random state, so it would return the same uuid repeatedly.

2) spawnedProcessExit and insertSpawned children would do a mish-mash of parent and child pids, so the search/insertion would fail.

3) WEXITSTATUS would do an unnecessary shift, resulting in the wrong return code.