### PR TITLE
Fix return code for spawnvpe/waitpid.

### DIFF
--- a/library/c.lib_rev.h
+++ b/library/c.lib_rev.h
@@ -2,7 +2,7 @@
 #define REVISION		0
 #define SUBREVISION		0
 
-#define DATE			"27.08.2024"
+#define DATE			"31.08.2024"
 #define VERS			"clib4.library 1.0.0"
-#define VSTRING			"clib4.library 1.0.0 (27.08.2024)\r\n"
-#define VERSTAG			"\0$VER: clib4.library 1.0.0 (27.08.2024)"
+#define VSTRING			"clib4.library 1.0.0 (31.08.2024)\r\n"
+#define VERSTAG			"\0$VER: clib4.library 1.0.0 (31.08.2024)"

--- a/library/include/sys/wait.h
+++ b/library/include/sys/wait.h
@@ -8,8 +8,8 @@ __BEGIN_DECLS
 
 #define WNOHANG 1
 #define WUNTRACED 2
-   
-#define WIFEXITED(w)	(((w) & 0xff) == 0)
+
+#define WIFEXITED(w)	(((w) & 0x80000000) == 0)
 #define WIFSIGNALED(w)	(((w) & 0x7f) > 0 && (((w) & 0x7f) < 0x7f))
 #define WIFSTOPPED(w)	(((w) & 0xff) == 0x7f)
 #define WEXITSTATUS(w)	(((w)) & 0x000000ff)

--- a/library/misc/children.h
+++ b/library/misc/children.h
@@ -7,7 +7,7 @@
 
 #include "clib4.h"
 
-BOOL insertSpawnedChildren(uint32 pid, uint32 gid);
+BOOL insertSpawnedChildren(uint32 pid, uint32 ppid, uint32 gid);
 struct Clib4Children *findSpawnedChildrenByPid(uint32 pid);
 struct Clib4Children *findSpawnedChildrenByGid(uint32 pid, uint32 gid);
 void spawnedProcessExit(int32 rc, int32 data UNUSED);


### PR DESCRIPTION
1) Redo return code for spawnees, so that WIFEXITED() tests for a flag (0x80000000)
2) Fix entry code for spawnees, so that group id is supplied though the entry data parameter. This is because, apparently, opening usergroup.library inside entry code makes it crash.
3) Change number of arguments for insertSpawnedChildren().

This update will enable cmake to build a valid makefile project.