### PR TITLE
Revert initializer to 0 instead of EOF (stdio/fwrite.c).

### DIFF
--- a/library/c.lib_rev.h
+++ b/library/c.lib_rev.h
@@ -2,7 +2,7 @@
 #define REVISION		0
 #define SUBREVISION		0
 
-#define DATE			"31.08.2024"
+#define DATE			"01.09.2024"
 #define VERS			"clib4.library 1.0.0"
-#define VSTRING			"clib4.library 1.0.0 (31.08.2024)\r\n"
-#define VERSTAG			"\0$VER: clib4.library 1.0.0 (31.08.2024)"
+#define VSTRING			"clib4.library 1.0.0 (01.09.2024)\r\n"
+#define VERSTAG			"\0$VER: clib4.library 1.0.0 (01.09.2024)"

--- a/library/stdio/fwrite.c
+++ b/library/stdio/fwrite.c
@@ -13,7 +13,7 @@
 size_t
 fwrite(const void *ptr, size_t element_size, size_t count, FILE *stream) {
     struct iob *file = (struct iob *) stream;
-    size_t result = EOF;
+    size_t result = 0; //EOF??;
     struct _clib4 *__clib4 = __CLIB4;
 
     ENTER();


### PR DESCRIPTION
Revert initializer to 0 instead of EOF (stdio/fwrite.c). Fixes problem with c++ output and empty string objects.