### PR TITLE
Set dicord announcements on PRs

### DIFF
--- a/.github/workflows/mergeMainBranches.yml
+++ b/.github/workflows/mergeMainBranches.yml
@@ -59,6 +59,6 @@ jobs:
       with:
         webhook_id: ${{ secrets.DISCORD_ANNOUNCEMENTS_ID }}
         webhook_token: ${{ secrets.DISCORD_ANNOUNCEMENTS_TOKEN }}
-        message: "clib4: New code merged into **${{ github.event.pull_request.base.ref }}**. Check it out at: ${{ github.event.pull_request.html_url }} {{ github.event.pull_request.compare_url }}"
+        message: "clib4: New code merged into **${{ github.event.pull_request.base.ref }}**. Check it out at: ${{ github.event.pull_request.html_url }} {{ github.event.pull_request.base.repo.compare_url }}"
         username: "GitHub Actions"
         avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"

--- a/.github/workflows/mergeMainBranches.yml
+++ b/.github/workflows/mergeMainBranches.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches:
       - master
+      - development
+      - set-dicord-announcements-on-PRs
     types:
       - closed
 
@@ -46,3 +48,17 @@ jobs:
 
       - name: Create the release archive
         run: make -f GNUmakefile.os4 release
+
+  announcements:
+    needs: [compile-ppc, compile-spe]
+    name: Notify on Discord on successful PR merge
+    runs-on: ubuntu-latest
+    steps:
+    - name: Discord notification
+      uses: appleboy/discord-action@master
+      with:
+        webhook_id: ${{ secrets.DISCORD_ANNOUNCEMENTS_ID }}
+        webhook_token: ${{ secrets.DISCORD_ANNOUNCEMENTS_TOKEN }}
+        message: "clib4: New code merged into **${{ github.event.pull_request.base.ref }}**. Check it out at: ${{ github.event.pull_request.html_url }}"
+        username: "GitHub Actions"
+        avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"

--- a/.github/workflows/mergeMainBranches.yml
+++ b/.github/workflows/mergeMainBranches.yml
@@ -68,6 +68,6 @@ jobs:
       with:
         webhook_id: ${{ secrets.DISCORD_ANNOUNCEMENTS_ID }}
         webhook_token: ${{ secrets.DISCORD_ANNOUNCEMENTS_TOKEN }}
-        message: "{{ github.event.pull_request.base.repo.compare_url }}"
+        message: "{{ github.server_url }}/{{ github.repository }}/compare/{{ github.event.pull_request.base.ref }}...{{ github.event.pull_request.head.ref }}"
         username: "GitHub Actions"
         avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"

--- a/.github/workflows/mergeMainBranches.yml
+++ b/.github/workflows/mergeMainBranches.yml
@@ -68,6 +68,6 @@ jobs:
       with:
         webhook_id: ${{ secrets.DISCORD_ANNOUNCEMENTS_ID }}
         webhook_token: ${{ secrets.DISCORD_ANNOUNCEMENTS_TOKEN }}
-        message: "{{ github.server_url }}/{{ github.repository }}/compare/{{ github.event.pull_request.base.ref }}...{{ github.event.pull_request.head.ref }}"
+        message: "Compare it at: ${{ github.event.pull_request.base.repo.html_url }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
         username: "GitHub Actions"
         avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"

--- a/.github/workflows/mergeMainBranches.yml
+++ b/.github/workflows/mergeMainBranches.yml
@@ -59,15 +59,6 @@ jobs:
       with:
         webhook_id: ${{ secrets.DISCORD_ANNOUNCEMENTS_ID }}
         webhook_token: ${{ secrets.DISCORD_ANNOUNCEMENTS_TOKEN }}
-        message: "clib4: New code merged into **${{ github.event.pull_request.base.ref }}**. Check it out at: ${{ github.event.pull_request.html_url }}"
-        username: "GitHub Actions"
-        avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-
-    - name: Compare notification
-      uses: appleboy/discord-action@master
-      with:
-        webhook_id: ${{ secrets.DISCORD_ANNOUNCEMENTS_ID }}
-        webhook_token: ${{ secrets.DISCORD_ANNOUNCEMENTS_TOKEN }}
-        message: "Compare it at: ${{ github.event.pull_request.base.repo.html_url }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+        message: "clib4: New code merged into **${{ github.event.pull_request.base.ref }}**. Check it out at: ${{ github.event.pull_request.html_url }}. Compare it at: ${{ github.event.pull_request.base.repo.html_url }}/compare/${{ github.event.pull_request.base.sha.slice(0, 7) }}...${{ github.event.pull_request.head.sha.slice(0, 7) }}"
         username: "GitHub Actions"
         avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"

--- a/.github/workflows/mergeMainBranches.yml
+++ b/.github/workflows/mergeMainBranches.yml
@@ -54,11 +54,20 @@ jobs:
     name: Notify on Discord on successful PR merge
     runs-on: ubuntu-latest
     steps:
-    - name: Discord notification
+    - name: PR notification
       uses: appleboy/discord-action@master
       with:
         webhook_id: ${{ secrets.DISCORD_ANNOUNCEMENTS_ID }}
         webhook_token: ${{ secrets.DISCORD_ANNOUNCEMENTS_TOKEN }}
-        message: "clib4: New code merged into **${{ github.event.pull_request.base.ref }}**. Check it out at: ${{ github.event.pull_request.html_url }} {{ github.event.pull_request.base.repo.compare_url }}"
+        message: "clib4: New code merged into **${{ github.event.pull_request.base.ref }}**. Check it out at: ${{ github.event.pull_request.html_url }}"
+        username: "GitHub Actions"
+        avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+
+    - name: Compare notification
+      uses: appleboy/discord-action@master
+      with:
+        webhook_id: ${{ secrets.DISCORD_ANNOUNCEMENTS_ID }}
+        webhook_token: ${{ secrets.DISCORD_ANNOUNCEMENTS_TOKEN }}
+        message: "{{ github.event.pull_request.base.repo.compare_url }}"
         username: "GitHub Actions"
         avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"

--- a/.github/workflows/mergeMainBranches.yml
+++ b/.github/workflows/mergeMainBranches.yml
@@ -59,6 +59,6 @@ jobs:
       with:
         webhook_id: ${{ secrets.DISCORD_ANNOUNCEMENTS_ID }}
         webhook_token: ${{ secrets.DISCORD_ANNOUNCEMENTS_TOKEN }}
-        message: "clib4: New code merged into **${{ github.event.pull_request.base.ref }}**. Check it out at: ${{ github.event.pull_request.html_url }}. Compare it at: ${{ github.event.pull_request.base.repo.html_url }}/compare/${{ github.event.pull_request.base.sha.slice(0, 7) }}...${{ github.event.pull_request.head.sha.slice(0, 7) }}"
+        message: "clib4: New code merged into **${{ github.event.pull_request.base.ref }}**. Check it out at: ${{ github.event.pull_request.html_url }}. Compare it at: ${{ github.event.pull_request.base.repo.html_url }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
         username: "GitHub Actions"
         avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"

--- a/.github/workflows/mergeMainBranches.yml
+++ b/.github/workflows/mergeMainBranches.yml
@@ -1,4 +1,4 @@
-name: Merge into master build
+name: Merge into main branches
 on:
   pull_request:
     branches:
@@ -9,48 +9,48 @@ on:
       - closed
 
 jobs:
-  compile-ppc:
-    name: Build for PowerPC cpus
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
-    container:
-      image: walkero/amigagccondocker:os4-gcc11
-      volumes:
-        - '${{ github.workspace }}:/opt/code'
-    steps:
-      - name: Pull code
-        uses: actions/checkout@v4
+  # compile-ppc:
+  #   name: Build for PowerPC cpus
+  #   runs-on: ubuntu-latest
+  #   if: github.event.pull_request.merged == true
+  #   container:
+  #     image: walkero/amigagccondocker:os4-gcc11
+  #     volumes:
+  #       - '${{ github.workspace }}:/opt/code'
+  #   steps:
+  #     - name: Pull code
+  #       uses: actions/checkout@v4
 
-      - name: Compile clib4
-        uses: ./.github/actions/compile
-        with:
-          spe: "no"
+  #     - name: Compile clib4
+  #       uses: ./.github/actions/compile
+  #       with:
+  #         spe: "no"
 
-      - name: Create the release archive
-        run: make -f GNUmakefile.os4 release
+  #     - name: Create the release archive
+  #       run: make -f GNUmakefile.os4 release
 
-  compile-spe:
-    name: Build for PowerPC SPE cpus
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
-    container:
-      image: walkero/amigagccondocker:os4-gcc6
-      volumes:
-        - '${{ github.workspace }}:/opt/code'
-    steps:
-      - name: Pull code
-        uses: actions/checkout@v4
+  # compile-spe:
+  #   name: Build for PowerPC SPE cpus
+  #   runs-on: ubuntu-latest
+  #   if: github.event.pull_request.merged == true
+  #   container:
+  #     image: walkero/amigagccondocker:os4-gcc6
+  #     volumes:
+  #       - '${{ github.workspace }}:/opt/code'
+  #   steps:
+  #     - name: Pull code
+  #       uses: actions/checkout@v4
 
-      - name: Compile clib4
-        uses: ./.github/actions/compile
-        with:
-          spe: "yes"
+  #     - name: Compile clib4
+  #       uses: ./.github/actions/compile
+  #       with:
+  #         spe: "yes"
 
-      - name: Create the release archive
-        run: make -f GNUmakefile.os4 release
+  #     - name: Create the release archive
+  #       run: make -f GNUmakefile.os4 release
 
   announcements:
-    needs: [compile-ppc, compile-spe]
+    # needs: [compile-ppc, compile-spe]
     name: Notify on Discord on successful PR merge
     runs-on: ubuntu-latest
     steps:
@@ -59,6 +59,6 @@ jobs:
       with:
         webhook_id: ${{ secrets.DISCORD_ANNOUNCEMENTS_ID }}
         webhook_token: ${{ secrets.DISCORD_ANNOUNCEMENTS_TOKEN }}
-        message: "clib4: New code merged into **${{ github.event.pull_request.base.ref }}**. Check it out at: ${{ github.event.pull_request.html_url }}"
+        message: "clib4: New code merged into **${{ github.event.pull_request.base.ref }}**. Check it out at: ${{ github.event.pull_request.html_url }} {{ github.event.pull_request.compare_url }}"
         username: "GitHub Actions"
         avatar_url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"

--- a/.github/workflows/mergeMainBranches.yml
+++ b/.github/workflows/mergeMainBranches.yml
@@ -4,53 +4,52 @@ on:
     branches:
       - master
       - development
-      - set-dicord-announcements-on-PRs
     types:
       - closed
 
 jobs:
-  # compile-ppc:
-  #   name: Build for PowerPC cpus
-  #   runs-on: ubuntu-latest
-  #   if: github.event.pull_request.merged == true
-  #   container:
-  #     image: walkero/amigagccondocker:os4-gcc11
-  #     volumes:
-  #       - '${{ github.workspace }}:/opt/code'
-  #   steps:
-  #     - name: Pull code
-  #       uses: actions/checkout@v4
+  compile-ppc:
+    name: Build for PowerPC cpus
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    container:
+      image: walkero/amigagccondocker:os4-gcc11
+      volumes:
+        - '${{ github.workspace }}:/opt/code'
+    steps:
+      - name: Pull code
+        uses: actions/checkout@v4
 
-  #     - name: Compile clib4
-  #       uses: ./.github/actions/compile
-  #       with:
-  #         spe: "no"
+      - name: Compile clib4
+        uses: ./.github/actions/compile
+        with:
+          spe: "no"
 
-  #     - name: Create the release archive
-  #       run: make -f GNUmakefile.os4 release
+      - name: Create the release archive
+        run: make -f GNUmakefile.os4 release
 
-  # compile-spe:
-  #   name: Build for PowerPC SPE cpus
-  #   runs-on: ubuntu-latest
-  #   if: github.event.pull_request.merged == true
-  #   container:
-  #     image: walkero/amigagccondocker:os4-gcc6
-  #     volumes:
-  #       - '${{ github.workspace }}:/opt/code'
-  #   steps:
-  #     - name: Pull code
-  #       uses: actions/checkout@v4
+  compile-spe:
+    name: Build for PowerPC SPE cpus
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    container:
+      image: walkero/amigagccondocker:os4-gcc6
+      volumes:
+        - '${{ github.workspace }}:/opt/code'
+    steps:
+      - name: Pull code
+        uses: actions/checkout@v4
 
-  #     - name: Compile clib4
-  #       uses: ./.github/actions/compile
-  #       with:
-  #         spe: "yes"
+      - name: Compile clib4
+        uses: ./.github/actions/compile
+        with:
+          spe: "yes"
 
-  #     - name: Create the release archive
-  #       run: make -f GNUmakefile.os4 release
+      - name: Create the release archive
+        run: make -f GNUmakefile.os4 release
 
   announcements:
-    # needs: [compile-ppc, compile-spe]
+    needs: [compile-ppc, compile-spe]
     name: Notify on Discord on successful PR merge
     runs-on: ubuntu-latest
     steps:

--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -254,9 +254,9 @@ clean:
 ##############################################################################
 
 gitver:
+ifdef GITTAG
 	$(VERBOSE)sed -i 's/[(]\([0-9]*\.[0-9]*\.[0-9]*\)[)]/($(DATESTR))/g' library/c.lib_rev.h
 	$(VERBOSE)sed -i 's/"\([0-9]*\.[0-9]*\.[0-9]*\)"/"$(DATESTR)"/g' library/c.lib_rev.h
-ifdef GITTAG
 	$(VERBOSE)sed -i 's/VERSION\t*[0-9]*/VERSION\t\t\t$(MAJOR)/g' library/c.lib_rev.h
 	$(VERBOSE)sed -i 's/REVISION\t*[0-9]*/REVISION\t\t$(MINOR)/g' library/c.lib_rev.h
 	$(VERBOSE)sed -i 's/SUBREVISION\t*[0-9]*/SUBREVISION\t\t$(PATCH)/g' library/c.lib_rev.h
@@ -442,7 +442,7 @@ release:
 	-$(COPY) libs/libauto.a clib4/lib/
 	-$(COPY) $(OUTPUT_LIB)/* clib4/lib/
 	-$(COPY) $(LIB_ROOT)/library/include/* clib4/include/
-	lha -ao5i clib4.lha clib4 clib4.info
+	@lha -ao5i clib4.lha clib4 clib4.info
 	-$(DELETE) clib4
 	-$(DELETE) clib4.info
 

--- a/dummy1
+++ b/dummy1
@@ -1,7 +1,0 @@
-This is a change
-2nd change
-3rd change
-4th change
-5th change
-6th change
-7th change


### PR DESCRIPTION
This change adds the development branch into those that the mergePR github action will run. Now, when a PR is merged into master or development, the github action will doing the following

- Build clib4 for PPC and SPE. This is useful to make sure that it still compiles
- Sent a notification to the announcements channel in the team's Discord server, informing about the PR and its changes