### PR TITLE
NECESSARY fix for the workbench startup message issue.

### DIFF
--- a/library/crtbegin.c
+++ b/library/crtbegin.c
@@ -13,6 +13,8 @@
 #include <proto/dos.h>
 #include <proto/utility.h>
 
+#include <workbench/startup.h>
+
 #include "shared_library/interface.h"
 
 #include "c.lib_rev.h"
@@ -112,11 +114,23 @@ clib4_start(char *args, const int32 arglen, struct Library *sysbase) {
     int rc = -1;
     void *old_r13 = r13;
 
+    struct Process *me;
+    struct WBStartup *sms = NULL;
+
     r13 = &_SDA_BASE_;
     SysBase = sysbase;
 
     iexec = (struct ExecIFace *) ((struct ExecBase *) SysBase)->MainInterface;
     iexec->Obtain();
+
+    /* Pick up the Workbench startup message, if available. */
+    me = (struct Process *) iexec->FindTask(NULL);
+    if (!me->pr_CLI) {
+        struct MsgPort *mp = &me->pr_MsgPort;
+        iexec->WaitPort(mp);
+        sms = (struct WBStartup *) iexec->GetMsg(mp);
+        iexec->DebugPrintF("<crtbegin> : NumArgs == %ld\n", sms->sm_NumArgs);
+    }
 
     IExec = iexec;
     idos = (struct DOSIFace *) OpenLibraryInterface(iexec, "dos.library", MIN_OS_VERSION);
@@ -131,7 +145,7 @@ clib4_start(char *args, const int32 arglen, struct Library *sysbase) {
                 if (clib4base->lib_Version >= VERSION && clib4base->lib_Revision >= REVISION) {
                     IClib4 = iclib4;
 
-                    rc = iclib4->library_start(args, arglen, main, __CTOR_LIST__, __DTOR_LIST__);
+                    rc = iclib4->library_start(args, arglen, main, __CTOR_LIST__, __DTOR_LIST__, sms);
                 }
                 else {
                     idos->Printf("This program requires clib4.library version %ld.%ld\n", VERSION, REVISION);

--- a/library/shared_library/clib4.c
+++ b/library/shared_library/clib4.c
@@ -873,9 +873,10 @@ library_start(char *argstr,
               int arglen,
               int (*start_main)(int, char **),
               void (*__EXT_CTOR_LIST__[])(void),
-              void (*__EXT_DTOR_LIST__[])(void)) {
+              void (*__EXT_DTOR_LIST__[])(void),
+              struct WBStartup *sms) {
 
-    int result = _main(argstr, arglen, start_main, __EXT_CTOR_LIST__, __EXT_DTOR_LIST__);
+    int result = _main(argstr, arglen, start_main, __EXT_CTOR_LIST__, __EXT_DTOR_LIST__, sms);
 
     return result;
 }

--- a/library/shared_library/clib4.h
+++ b/library/shared_library/clib4.h
@@ -93,7 +93,8 @@ int library_start(char *argstr,
                   int arglen,
                   int (*start_main)(int, char **),
                   void (*__EXT_CTOR_LIST__[])(void),
-                  void (*__EXT_DTOR_LIST__[])(void));
+                  void (*__EXT_DTOR_LIST__[])(void),
+                  struct WBStartup *sms);
 
 int32 _start(STRPTR args,
              int32 arglen,
@@ -103,7 +104,8 @@ extern int _main(char *argstr,
                  int arglen,
                  int (*start_main)(int, char **),
                  void (*__EXT_CTOR_LIST__[])(void),
-                 void (*__EXT_DTOR_LIST__[])(void));
+                 void (*__EXT_DTOR_LIST__[])(void),
+                 struct WBStartup *sms);
 
 
 #endif

--- a/library/shared_library/interface.h
+++ b/library/shared_library/interface.h
@@ -103,7 +103,7 @@ struct Clib4IFace {
     void APICALL (*Expunge)(struct Clib4IFace *Self);                       //68
     struct Clib4IFace *APICALL (*Clone)(struct Clib4IFace *Self);           //72
     /* internal */
-    int  (* library_start)(char *argstr, int arglen, int (* start_main)(int, char **), void (*__CTOR_LIST__[])(void), void (*__DTOR_LIST__[])(void)); //76
+    int  (* library_start)(char *argstr, int arglen, int (* start_main)(int, char **), void (*__CTOR_LIST__[])(void), void (*__DTOR_LIST__[])(void), struct WBStartup *sms); //76
     struct _clib4 * (* __getClib4)(void);                                   //80
     void (* internal1)(void);                                               //84
     void (* __translate_amiga_to_unix_path_name)(void);                     //88

--- a/library/stdlib/main.c
+++ b/library/stdlib/main.c
@@ -162,22 +162,16 @@ _main(
         int arglen,
         int (*start_main)(int, char **),
         void (*__EXT_CTOR_LIST__[])(void),
-        void (*__EXT_DTOR_LIST__[])(void)) {
-    struct WBStartup *sms = NULL;
+        void (*__EXT_DTOR_LIST__[])(void),
+        struct WBStartup *sms
+    ) {
     struct Process *me;
     APTR oldClib4Data;
     int rc = RETURN_FAIL;
     struct _clib4 *__clib4 = __CLIB4;
 
-    /* Pick up the Workbench startup message, if available. */
-    me = (struct Process *) FindTask(NULL);
-    if (!me->pr_CLI) {
-        struct MsgPort *mp = &me->pr_MsgPort;
-        WaitPort(mp);
-        sms = (struct WBStartup *) GetMsg(mp);
-    }
-
     /* Store old Clib4Data */
+    me = (struct Process *) FindTask(NULL);
     oldClib4Data = (APTR) me->pr_UID;
 
     __clib4->__WBenchMsg = sms;

--- a/library/stdlib/stdlib_headers.h
+++ b/library/stdlib/stdlib_headers.h
@@ -111,7 +111,8 @@ extern int _main(char *argstr,
                  int arglen,
                  int (*start_main)(int, char **),
                  void (*__EXT_CTOR_LIST__[])(void),
-                 void (*__EXT_DTOR_LIST__[])(void));
+                 void (*__EXT_DTOR_LIST__[])(void),
+                 struct WBStartup *sms);
 
 #ifndef _STDLIB_PROTOS_H
 #include "stdlib_protos.h"


### PR DESCRIPTION
The WBMessage needs to be fetched right at the beginning of the startup code (this is for static objects).

Refer to the system includes (dos/startup.h):

 *  Mandatory Caveats;
 *    1) It is never permissable to open libraries or call any dos.library
 *       functions or perform any i/o whatsoever, directly or indirectly
 *       from this process context, before a workbench startup message
 *       has been fetched from the process structure message port. 

This has been violated in the previous versions, and hence this will be a backwards-INCOMPATIBLE api change for the library_startup and _main functions.