### PR TITLE
Implemented pthread_cond_clockwait, pthread_condattr_getclock and pthread_setclock

### DIFF
--- a/libpthread.gmk
+++ b/libpthread.gmk
@@ -53,12 +53,15 @@ PTHREAD_LIB := \
     pthread/pthread_cond_destroy.o \
     pthread/pthread_cond_init.o \
     pthread/pthread_cond_signal.o \
+    pthread/pthread_cond_clockwait.o \
     pthread/pthread_cond_timedwait.o \
     pthread/pthread_cond_timedwait_relative_np.o \
     pthread/pthread_cond_wait.o \
     pthread/pthread_condattr_destroy.o \
     pthread/pthread_condattr_init.o \
+    pthread/pthread_condattr_getclock.o \
     pthread/pthread_condattr_getpshared.o \
+    pthread/pthread_condattr_setclock.o \
     pthread/pthread_condattr_setpshared.o \
     pthread/pthread_create.o \
     pthread/pthread_detach.o \

--- a/library/include/pthread.h
+++ b/library/include/pthread.h
@@ -167,19 +167,21 @@ typedef struct pthread_mutex pthread_mutex_t;
 
 struct pthread_condattr {
     int pshared;
+    clockid_t clock_type;
 };
 
 typedef struct pthread_condattr pthread_condattr_t;
 
 struct pthread_cond {
     int pad1;
-    void* semaphore; // SignalSemaphore
-    void* waiters;	// MinList
+    void* semaphore;                // SignalSemaphore
+    void* waiters;	                // MinList
+    pthread_condattr_t *condattr;   // cond_attr used to store for example clock type
 };
 
 typedef struct pthread_cond pthread_cond_t;
 
-#define PTHREAD_COND_INITIALIZER {0, 0, 0}
+#define PTHREAD_COND_INITIALIZER {0, 0, 0, 0}
 
 //
 // Barriers
@@ -323,6 +325,8 @@ extern int pthread_condattr_init(pthread_condattr_t *attr);
 extern int pthread_condattr_destroy(pthread_condattr_t *attr);
 extern int pthread_condattr_getpshared(const pthread_condattr_t *attr, int *pshared);
 extern int pthread_condattr_setpshared(pthread_condattr_t *attr, int pshared);
+extern int pthread_condattr_setclock(pthread_condattr_t *attrp, clockid_t clk);
+extern int pthread_condattr_getclock(const pthread_condattr_t *attrp, clockid_t *outp);
 
 //
 // Condition variable functions
@@ -332,6 +336,7 @@ extern int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *att
 extern int pthread_cond_destroy(pthread_cond_t *cond);
 extern int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex);
 extern int pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime);
+extern int pthread_cond_clockwait(pthread_cond_t *cond, pthread_mutex_t *mutex, clockid_t clock_id, const struct timespec *abstime);
 extern int pthread_cond_signal(pthread_cond_t *cond);
 extern int pthread_cond_broadcast(pthread_cond_t *cond);
 

--- a/library/pthread/pthread.c
+++ b/library/pthread/pthread.c
@@ -89,6 +89,16 @@ _pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr, BOO
     return 0;
 }
 
+static void timespec_sub(struct timespec *ts1, const struct timespec *ts2, const struct timespec *ts3) {
+    ts1->tv_sec = ts2->tv_sec - ts3->tv_sec;
+    if (ts2->tv_nsec < ts3->tv_nsec) {
+        ts1->tv_sec--;
+        ts1->tv_nsec = ts2->tv_nsec - ts3->tv_nsec + 1000000000; // Add 1 billion ns (1s)
+    } else {
+        ts1->tv_nsec = ts2->tv_nsec - ts3->tv_nsec;
+    }
+}
+
 int
 _pthread_obtain_sema_timed(struct SignalSemaphore *sema, const struct timespec *abstime, int shared) {
     struct MsgPort msgport;
@@ -154,16 +164,23 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
     struct MsgPort timermp;
     struct TimeRequest timerio;
     struct Task *task;
+    clock_t clock_type = CLOCK_MONOTONIC;
+    if (cond->condattr != NULL)
+        clock_type = cond->condattr->clock_type;
 
     if (cond == NULL || mutex == NULL)
         return EINVAL;
+
+    /* Check for supported clock type */
+    if ((clock_type & ~(CLOCK_MONOTONIC | CLOCK_REALTIME | CLOCK_MONOTONIC_RAW)) != 0) {
+        return EINVAL;
+    }
 
     // initialize static conditions
     if (SemaphoreIsInvalid(cond->semaphore))
         pthread_cond_init(cond, NULL);
 
     task = FindTask(NULL);
-
     if (abstime) {
         // open timer.device
         if (!OpenTimerDevice((struct IORequest *) &timerio, &timermp, task)) {
@@ -174,19 +191,20 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
         // prepare the device command and send it
         timerio.Request.io_Command = TR_ADDREQUEST;
         timerio.Request.io_Flags = 0;
-        TIMESPEC_TO_OLD_TIMEVAL(&timerio.Time, abstime);
         if (!relative) {
-            struct TimeVal starttime;
+            struct timespec starttime;
+			struct timespec endtime;
             // absolute time has to be converted to relative
-            // GetSysTime can't be used due to the timezone offset in abstime
-            gettimeofday((struct timeval *)&starttime, NULL);
-            timersub(&timerio.Time, &starttime, &timerio.Time);
+			clock_gettime(clock_type, &starttime);
+            timespec_sub(&endtime, abstime, &starttime);
+			TIMESPEC_TO_OLD_TIMEVAL(&timerio.Time, &endtime);
             if (!timerisset(&timerio.Time)) {
                 CloseTimerDevice((struct IORequest *) &timerio);
                 return ETIMEDOUT;
             }
         }
         sigs |= (1 << timermp.mp_SigBit);
+        SetSignal(0, sigs);
         SendIO((struct IORequest *) &timerio);
     }
 

--- a/library/pthread/pthread_cond_clockwait.c
+++ b/library/pthread/pthread_cond_clockwait.c
@@ -1,0 +1,21 @@
+/*
+	$Id: pthread_cond_clockwait.c,v 1.00 2025-11-02 12:09:49 clib4devs Exp $
+*/
+
+#ifndef _TIME_HEADERS_H
+#include "time_headers.h"
+#endif /* _TIME_HEADERS_H */
+
+#include "common.h"
+#include "pthread.h"
+
+int
+pthread_cond_clockwait(pthread_cond_t *cond, pthread_mutex_t *mutex, clockid_t clock_id, const struct timespec *abstime) {
+	if (cond != NULL && cond->condattr == NULL) {
+		pthread_condattr_t attr;
+		pthread_condattr_init(&attr);
+		cond->condattr = &attr;
+	}
+
+	return pthread_cond_timedwait(cond, mutex, abstime);
+}

--- a/library/pthread/pthread_cond_init.c
+++ b/library/pthread/pthread_cond_init.c
@@ -39,11 +39,10 @@
 
 int
 pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr) {
-    (void) attr;
     if (cond == NULL) {
         return EINVAL;
 	}
-
+	cond->condattr = attr;
 	cond->semaphore = AllocSysObjectTags(ASOT_SEMAPHORE,TAG_END);
 	if (!cond->semaphore)
 		return ENOMEM;

--- a/library/pthread/pthread_condattr_destroy.c
+++ b/library/pthread/pthread_condattr_destroy.c
@@ -43,6 +43,7 @@ pthread_condattr_destroy(pthread_condattr_t *attr) {
         return EINVAL;
 
     memset(attr, 0, sizeof(pthread_condattr_t));
+	attr->clock_type = CLOCK_MONOTONIC;
 
     return 0;
 }

--- a/library/pthread/pthread_condattr_getclock.c
+++ b/library/pthread/pthread_condattr_getclock.c
@@ -1,0 +1,15 @@
+/*
+$Id: pthread_condattr_getclock.c,v 1.00 2025-10-31 12:09:49 clib4devs Exp $
+*/
+
+#ifndef _UNISTD_HEADERS_H
+#include "unistd_headers.h"
+#endif /* _UNISTD_HEADERS_H */
+
+int
+pthread_condattr_getclock(const pthread_condattr_t *attrp, clockid_t *outp) {
+
+	*outp = attrp->clock_type;
+
+	return 0;
+}

--- a/library/pthread/pthread_condattr_init.c
+++ b/library/pthread/pthread_condattr_init.c
@@ -43,6 +43,7 @@ pthread_condattr_init(pthread_condattr_t *attr) {
         return EINVAL;
 
     memset(attr, 0, sizeof(pthread_condattr_t));
+	attr->clock_type = CLOCK_MONOTONIC;
 
     return 0;
 }

--- a/library/pthread/pthread_condattr_setclock.c
+++ b/library/pthread/pthread_condattr_setclock.c
@@ -1,0 +1,17 @@
+/*
+$Id: pthread_condattr_setclock.c,v 1.00 2025-10-31 12:09:49 clib4devs Exp $
+*/
+
+#ifndef _UNISTD_HEADERS_H
+#include "unistd_headers.h"
+#endif /* _UNISTD_HEADERS_H */
+
+int
+pthread_condattr_setclock(pthread_condattr_t *attrp, clockid_t clk) {
+	if (clk != CLOCK_REALTIME && clk != CLOCK_MONOTONIC)
+		return (EINVAL);
+
+	attrp->clock_type = clk;
+
+	return 0;
+}

--- a/library/pthread/pthread_create.c
+++ b/library/pthread/pthread_create.c
@@ -56,6 +56,9 @@ StarterFunc() {
 
     struct _clib4 *__clib4 = (struct _clib4 *) startedTask->pr_EntryData; // GetEntryData();
 
+    // we have to set the priority here to avoid race conditions
+    SetTaskPri((struct Task *) inf->task, inf->attr.param.sched_priority);
+
     // custom stack requires special handling
     if (inf->attr.stackaddr != NULL && inf->attr.stacksize > 0) {
         // Check if we have a guardsize
@@ -75,8 +78,6 @@ StarterFunc() {
         inf->status = THREAD_STATE_RUNNING;
         inf->ret = inf->start(inf->arg);
     }
-
-    pthread_cleanup_pop(1);
 
     // destroy all non-NULL TLS key values
     // since the destructors can set the keys themselves, we have to do multiple iterations

--- a/library/pthread/pthread_exit.c
+++ b/library/pthread/pthread_exit.c
@@ -40,13 +40,16 @@
 void
 pthread_exit(void *value_ptr) {
     pthread_t thread = pthread_self();
+	CleanupHandler *handler;
     ThreadInfo *inf = GetThreadInfo(thread);
-    inf->ret = value_ptr;
 
-    ThreadInfo *mainThread = &threads[0];
-    /* If the function is called from main thread don't execute call longjmp */
-    if (inf != mainThread && inf->status == THREAD_STATE_RUNNING) {
-        inf->status = THREAD_STATE_DESTRUCT;
-        longjmp(inf->jmp, 1);
-    }
+	inf->ret = value_ptr;
+
+	// execute the clean-up handlers
+	while ((handler = (CleanupHandler *)RemTail((struct List *)&inf->cleanup)))
+		if (handler->routine)
+			handler->routine(handler->arg);
+	inf->status = THREAD_STATE_DESTRUCT;
+
+    longjmp(inf->jmp, 1);
 }


### PR DESCRIPTION
pthread_cond_timedwait now use clock_gettime instead of gettimeofday. 
Fix on pthread_exit was causing error on some small cases.
pthread_create had a wrong pthread_cleanup_pop() call that was causing issues when calling pthread_cleanup_push() from main program