### PR TITLE
Pre release actions

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -9,6 +9,10 @@ inputs:
   git_tag:
     description: 'Git tag to use'
     required: false
+  nightly:
+    description: 'Set if this is a nightly build'
+    required: false
+    default: "no"
 
 runs:
   using: "composite"
@@ -18,11 +22,11 @@ runs:
       if: ${{ inputs.spe != 'yes' }}
       run: |
         cd /opt/code && \
-        make -j1 -f GNUmakefile.os4 OS=os4 GITTAG=${{ inputs.git_tag }}
+        make -j -f GNUmakefile.os4 OS=os4 GITTAG=${{ inputs.git_tag }} NIGHTLY=${{ inputs.nightly }}
 
     - name: compiling SPE
       shell: bash
       if: ${{ inputs.spe == 'yes' }}
       run: |
         cd /opt/code && \
-        make -j1 -f GNUmakefile.os4 OS=os4 SPE=yes GITTAG=${{ inputs.git_tag }}
+        make -j -f GNUmakefile.os4 OS=os4 SPE=yes GITTAG=${{ inputs.git_tag }} NIGHTLY=${{ inputs.nightly }}

--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -22,11 +22,11 @@ runs:
       if: ${{ inputs.spe != 'yes' }}
       run: |
         cd /opt/code && \
-        make -j -f GNUmakefile.os4 OS=os4 GITTAG=${{ inputs.git_tag }} NIGHTLY=${{ inputs.nightly }}
+        make -j -f GNUmakefile.os4 GITTAG=${{ inputs.git_tag }} NIGHTLY=${{ inputs.nightly }}
 
     - name: compiling SPE
       shell: bash
       if: ${{ inputs.spe == 'yes' }}
       run: |
         cd /opt/code && \
-        make -j -f GNUmakefile.os4 OS=os4 SPE=yes GITTAG=${{ inputs.git_tag }} NIGHTLY=${{ inputs.nightly }}
+        make -j -f GNUmakefile.os4 SPE=yes GITTAG=${{ inputs.git_tag }} NIGHTLY=${{ inputs.nightly }}

--- a/.github/workflows/_compile.yml
+++ b/.github/workflows/_compile.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           git_tag: ${{ inputs.git_tag }}
           spe: ${{ inputs.spe }}
+          nightly: "no"
 
       - name: Create the LHA release archive
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           git_tag: ""
           spe: "no"
+          nightly: "yes"
 
       - name: Create the LHA release archive
         run: |
@@ -81,7 +82,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     container:
-      image: walkero/amigagccondocker:os4-gcc11
+      image: walkero/amigagccondocker:os4-gcc6
       volumes:
         - '${{ github.workspace }}:/opt/code'
     steps:
@@ -94,6 +95,7 @@ jobs:
         with:
           git_tag: ""
           spe: "yes"
+          nightly: "yes"
 
       - name: Create the LHA release archive
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,110 @@
+name: Nightly Builds
+
+on:
+  push:
+    branches:
+      - 'development'
+
+  workflow_dispatch:
+
+permissions: write-all
+
+jobs:
+  release:
+    name: Create Nightly Build
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      version: "nightly"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Set Tag
+        id: tag
+        run: |
+          echo "version=nightly" >> "$GITHUB_OUTPUT"
+      - name: Update Tag
+        uses: richardsimko/update-tag@v1
+        with:
+          tag_name: "nightly"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2.2.2
+        with:
+          tag_name: "nightly"
+          name: "clib4 nightly-builds"
+          draft: false
+          prerelease: true
+          generate_release_notes: true
+          body: >
+            Builds that include most recent changes as they happen. For non 
+            nightly builds check the whole list of [releases](https://github.com/AmigaLabs/clib4/releases).
+
+  build_non_spe:
+    name: Build non-SPE
+    needs: release
+    runs-on: ubuntu-latest
+    container:
+      image: walkero/amigagccondocker:os4-gcc11
+      volumes:
+        - '${{ github.workspace }}:/opt/code'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Compile clib4
+        uses: ./.github/actions/compile
+        with:
+          git_tag: ""
+          spe: "no"
+
+      - name: Create the LHA release archive
+        run: |
+          make -f GNUmakefile.os4 release && \
+          mv clib4.lha clib4-nightly.lha
+
+      - name: Upload Files
+        uses: softprops/action-gh-release@v2.2.2
+        with:
+          tag_name: "nightly"
+          draft: false
+          prerelease: true
+          files: |
+            clib4-nightly.lha
+
+  build_spe:
+    name: Build SPE
+    needs: release
+    runs-on: ubuntu-latest
+    container:
+      image: walkero/amigagccondocker:os4-gcc11
+      volumes:
+        - '${{ github.workspace }}:/opt/code'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Compile clib4
+        uses: ./.github/actions/compile
+        with:
+          git_tag: ""
+          spe: "yes"
+
+      - name: Create the LHA release archive
+        run: |
+          make -f GNUmakefile.os4 release && \
+          mv clib4.lha clib4-nightly_SPE.lha
+
+      - name: Upload Files
+        uses: softprops/action-gh-release@v2.2.2
+        with:
+          tag_name: "nightly"
+          draft: false
+          prerelease: true
+          files: |
+            clib4-nightly_SPE.lha

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,7 @@ jobs:
           draft: false
           prerelease: true
           generate_release_notes: true
+          target_commitish: development
           body: >
             Builds that include most recent changes as they happen. For non 
             nightly builds check the whole list of [releases](https://github.com/AmigaLabs/clib4/releases).
@@ -74,6 +75,7 @@ jobs:
           tag_name: "nightly"
           draft: false
           prerelease: true
+          target_commitish: development
           files: |
             clib4-nightly.lha
 
@@ -108,5 +110,6 @@ jobs:
           tag_name: "nightly"
           draft: false
           prerelease: true
+          target_commitish: development
           files: |
             clib4-nightly_SPE.lha

--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -168,15 +168,14 @@ DATESTR = $(shell date "+%d.%m.%Y")
 # Parse the repo tag to different defines, that will be used while
 # compiling clib4 library
 #
-# The tags should be like v(MAJOR).(MINOR).(PATCH)
-# in example v1.2.3
+# The tags should be like v(MAJOR).(MINOR)
+# in example v1.2
 #
 ifneq ($(origin GITTAG),undefined)
 MAJOR = $(patsubst v%,%,$(firstword $(subst ., ,$(GITTAG))))
 MINOR = $(word 2, $(subst ., ,$(GITTAG)))
-PATCH = $(word 3, $(subst ., ,$(GITTAG)))
-GIT_HASH = $(shell git rev-parse --short HEAD)
 endif
+GIT_HASH = $(shell git rev-parse --short HEAD)
 
 ##############################################################################
 
@@ -269,10 +268,13 @@ ifdef GITTAG
 	$(VERBOSE)sed -i 's/"\([0-9]*\.[0-9]*\.[0-9]*\)"/"$(DATESTR)"/g' library/c.lib_rev.h
 	$(VERBOSE)sed -i 's/VERSION\t*[0-9]*/VERSION\t\t\t$(MAJOR)/g' library/c.lib_rev.h
 	$(VERBOSE)sed -i 's/REVISION\t*[0-9]*/REVISION\t\t$(MINOR)/g' library/c.lib_rev.h
-	$(VERBOSE)sed -i 's/SUBREVISION\t*[0-9]*/SUBREVISION\t\t$(PATCH)/g' library/c.lib_rev.h
-	$(VERBOSE)sed -i 's/clib4.library [0-9]*\.[0-9]*\.[0-9]*/clib4.library $(MAJOR).$(MINOR).$(PATCH)/g' library/c.lib_rev.h
-	$(VERBOSE)sed -i 's/clib4.library [0-9]*\.[0-9]*\.[0-9]*-[a-z0-9]*/clib4.library $(MAJOR).$(MINOR).$(PATCH)-$(GIT_HASH)/g' library/c.lib_rev.h
-	$(VERBOSE)sed -i 's/Version: [0-9]*\.[0-9]*\.[0-9]*/Version: $(MAJOR).$(MINOR).$(PATCH)/g' misc/control
+	$(VERBOSE)sed -i 's/clib4.library [0-9]*\.[0-9]*/clib4.library $(MAJOR).$(MINOR)/g' library/c.lib_rev.h
+	$(VERBOSE)sed -i 's/clib4.library [0-9]*\.[0-9]*-[a-z0-9]*/clib4.library $(MAJOR).$(MINOR)-$(GIT_HASH)/g' library/c.lib_rev.h
+	$(VERBOSE)sed -i 's/Version: [0-9]*\.[0-9]*/Version: $(MAJOR).$(MINOR)/g' misc/control
+endif
+
+ifdef NIGHTLY
+	$(VERBOSE)sed -i 's/clib4.library \([0-9]*\.[0-9]*\)-\([a-z0-9]*\)/clib4.library \1-nightly-$(GIT_HASH)/g' library/c.lib_rev.h
 endif
 
 # Update the version numbers bound to the individual libraries

--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -263,9 +263,9 @@ clean:
 ##############################################################################
 
 gitver:
-ifdef GITTAG
 	$(VERBOSE)sed -i 's/[(]\([0-9]*\.[0-9]*\.[0-9]*\)[)]/($(DATESTR))/g' library/c.lib_rev.h
 	$(VERBOSE)sed -i 's/"\([0-9]*\.[0-9]*\.[0-9]*\)"/"$(DATESTR)"/g' library/c.lib_rev.h
+ifdef GITTAG
 	$(VERBOSE)sed -i 's/VERSION\t*[0-9]*/VERSION\t\t\t$(MAJOR)/g' library/c.lib_rev.h
 	$(VERBOSE)sed -i 's/REVISION\t*[0-9]*/REVISION\t\t$(MINOR)/g' library/c.lib_rev.h
 	$(VERBOSE)sed -i 's/clib4.library [0-9]*\.[0-9]*/clib4.library $(MAJOR).$(MINOR)/g' library/c.lib_rev.h

--- a/library/c.lib_rev.h
+++ b/library/c.lib_rev.h
@@ -3,6 +3,6 @@
 #define SUBREVISION		0
 
 #define DATE			"16.08.2025"
-#define VERS			"clib4.library 2.0.0"
-#define VSTRING			"clib4.library 2.0.0 (16.08.2025)\r\n"
-#define VERSTAG			"\0$VER: clib4.library 2.0.0-ab40f98 (16.08.2025)"
+#define VERS			"clib4.library 2.0"
+#define VSTRING			"clib4.library 2.0 (16.08.2025)\r\n"
+#define VERSTAG			"\0$VER: clib4.library 2.0-ab40f98 (16.08.2025)"

--- a/misc/control
+++ b/misc/control
@@ -1,5 +1,5 @@
 Package: amigaos4-clib4
-Version: 2.0.0
+Version: 2.0
 Maintainer: Andrea Palmatè <os4test@amigasoft.net>
 Architecture: amd64
 Section: libdevel


### PR DESCRIPTION
With this PR a new github action is created that is executed when we merge code to the development branch. What it does is creating/updating a new pre-release with compiled versions of clib4 (SPE and non-SPE) based on the latest code. This pre-release is always updated with new files, when the build is complete.

<img width="950" height="461" alt="image" src="https://github.com/user-attachments/assets/718f173a-1c22-40ff-a912-01ecea9e8e48" />

Here is what exactly that new github action does

<img width="766" height="428" alt="image" src="https://github.com/user-attachments/assets/05f2173f-c747-4f25-bfbb-761048827782" />

The `library/c.lib_rev.h` is updated like below

```
#define DATE			"20.01.2026"
#define VERS			"clib4.library 2.0"
#define VSTRING			"clib4.library 2.0 (20.01.2026)\r\n"
#define VERSTAG			"\0$VER: clib4.library 2.0-nightly-214eb4c4 (20.01.2026)"
```

As part of this work, I changed the library versioning to not use the SUBREVISION as the libraries, and the amiga versions in general, work with two numbers only.