### PR TITLE
Change cond.condattr from reference to instance.

### DIFF
--- a/library/include/pthread.h
+++ b/library/include/pthread.h
@@ -176,12 +176,12 @@ struct pthread_cond {
     int pad1;
     void* semaphore;                // SignalSemaphore
     void* waiters;	                // MinList
-    pthread_condattr_t *condattr;   // cond_attr used to store for example clock type
+    pthread_condattr_t condattr;   // cond_attr used to store for example clock type
 };
 
 typedef struct pthread_cond pthread_cond_t;
 
-#define PTHREAD_COND_INITIALIZER {0, 0, 0, 0}
+#define PTHREAD_COND_INITIALIZER { 0, 0, 0, { 0, CLOCK_REALTIME } }
 
 //
 // Barriers

--- a/library/pthread/pthread.c
+++ b/library/pthread/pthread.c
@@ -164,11 +164,13 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
     struct MsgPort timermp;
     struct TimeRequest timerio;
     struct Task *task;
-    clock_t clock_type = cond->condattr.clock_type;
+    clock_t clock_type = CLOCK_REALTIME;
 
     if (cond == NULL || mutex == NULL) {
         return EINVAL;
     }
+
+    clock_type = cond->condattr.clock_type;
 
     /* Check for supported clock type */
     if ((clock_type & ~(CLOCK_MONOTONIC | CLOCK_REALTIME | CLOCK_MONOTONIC_RAW)) != 0) {

--- a/library/pthread/pthread.c
+++ b/library/pthread/pthread.c
@@ -164,12 +164,11 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
     struct MsgPort timermp;
     struct TimeRequest timerio;
     struct Task *task;
-    clock_t clock_type = CLOCK_REALTIME;  // POSIX default is CLOCK_REALTIME
-    if (cond->condattr != NULL)
-        clock_type = cond->condattr->clock_type;
+    clock_t clock_type = cond->condattr.clock_type;
 
-    if (cond == NULL || mutex == NULL)
+    if (cond == NULL || mutex == NULL) {
         return EINVAL;
+    }
 
     /* Check for supported clock type */
     if ((clock_type & ~(CLOCK_MONOTONIC | CLOCK_REALTIME | CLOCK_MONOTONIC_RAW)) != 0) {

--- a/library/pthread/pthread_cond_init.c
+++ b/library/pthread/pthread_cond_init.c
@@ -42,8 +42,14 @@ pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr) {
     if (cond == NULL) {
         return EINVAL;
 	}
-	cond->condattr = attr;
-	cond->semaphore = AllocSysObjectTags(ASOT_SEMAPHORE,TAG_END);
+
+    pthread_condattr_t c = { 0, CLOCK_REALTIME };
+    if (attr)
+        cond->condattr = *attr;
+    else
+        cond->condattr = c;
+
+    cond->semaphore = AllocSysObjectTags(ASOT_SEMAPHORE,TAG_END);
 	if (!cond->semaphore)
 		return ENOMEM;
 


### PR DESCRIPTION
This will prevent pthread_condattr objects from going out of scope (Qt6).