### PR TITLE
Fix multiple critical and correctness bugs in pthread library

### DIFF
--- a/library/pthread/common.c
+++ b/library/pthread/common.c
@@ -125,7 +125,9 @@ OpenTimerDevice(struct IORequest *io, struct MsgPort *mp, struct Task *task) {
     signal = AllocSignal(-1);
     if (signal == -1) {
         signal = SIGB_TIMER_FALLBACK;
-        SetSignal(SIGF_TIMER_FALLBACK, 0);
+        /* Clear the fallback signal bit before use. SetSignal(0, mask) clears;
+         * previously had reversed args SetSignal(mask, 0) which is a no-op. */
+        SetSignal(0, SIGF_TIMER_FALLBACK);
     }
     mp->mp_SigBit = signal;
     NewList(&mp->mp_MsgList);

--- a/library/pthread/common.h
+++ b/library/pthread/common.h
@@ -92,7 +92,7 @@ typedef struct {
     struct MinList cleanup;
     int cancelstate;
     int canceltype;
-    int canceled;
+    volatile int canceled; /* volatile: written by pthread_cancel from another thread, polled by target */
     int detached;
     char name[NAMELEN];
     pthread_t thread_id;          /* My pthread_t ID assigned at creation */

--- a/library/pthread/pthread.c
+++ b/library/pthread/pthread.c
@@ -86,6 +86,13 @@ _pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr, BOO
 	mutex->owner = NULL;
     SHOWPOINTER(mutex->mutex);
 
+    /* Check for allocation failure — NULL return on OOM would crash on
+     * subsequent MutexObtain(NULL). */
+    if (mutex->mutex == NULL) {
+        LEAVE();
+        return ENOMEM;
+    }
+
     mutex->incond = 0;
 
     LEAVE();
@@ -142,8 +149,16 @@ _pthread_obtain_sema_timed(struct SignalSemaphore *sema, const struct timespec *
     WaitPort(&msgport);
     m1 = GetMsg(&msgport);
     m2 = GetMsg(&msgport);
-    if (m1 == &timerio.Request.io_Message || m2 == &timerio.Request.io_Message)
+    if (m1 == &timerio.Request.io_Message || m2 == &timerio.Request.io_Message) {
         Vacate(sema, &msg);
+        /* Drain the pending semaphore reply before destroying the stack-local msgport */
+        if (m2 == NULL) {
+            WaitPort(&msgport);
+            GetMsg(&msgport);
+        }
+    } else if (m2 == NULL) {
+        /* Semaphore acquired first, timer still pending — CloseTimerDevice will abort it */
+    }
 
     CloseTimerDevice((struct IORequest *) &timerio);
 
@@ -170,6 +185,35 @@ _pthread_clear_threadinfo(ThreadInfo *inf) {
     D(("_pthread_clear_threadinfo: EXIT\n"));
 }
 
+/* Cleanup context for cond_wait cancellation */
+typedef struct {
+    pthread_cond_t *cond;
+    pthread_mutex_t *mutex;
+    CondWaiter *waiter;
+    struct IORequest *timerio;  /* NULL if no timer active */
+} CondWaitCleanup;
+
+static void CondWaitCleanupHandler(void *arg) {
+    CondWaitCleanup *ctx = (CondWaitCleanup *) arg;
+
+    /* Remove the waiter node from the condvar's list */
+    ObtainSemaphore(ctx->cond->semaphore);
+    Remove((struct Node *) ctx->waiter);
+    ReleaseSemaphore(ctx->cond->semaphore);
+
+    /* Free the signal bit */
+    if (ctx->waiter->sigbit != SIGB_COND_FALLBACK)
+        FreeSignal(ctx->waiter->sigbit);
+
+    /* Abort and clean up timer if active */
+    if (ctx->timerio != NULL)
+        CloseTimerDevice(ctx->timerio);
+
+    /* POSIX: mutex must be re-acquired when cancelled during cond_wait */
+    pthread_mutex_lock(ctx->mutex);
+    ctx->mutex->incond--;
+}
+
 int
 _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime, BOOL relative) {
     CondWaiter waiter;
@@ -191,9 +235,13 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
         return EINVAL;
     }
 
-    // initialize static conditions
-    if (SemaphoreIsInvalid(cond->semaphore))
-        pthread_cond_init(cond, NULL);
+    // initialize static conditions (double-check under lock)
+    if (SemaphoreIsInvalid(cond->semaphore)) {
+        MutexObtain(thread_sem);
+        if (SemaphoreIsInvalid(cond->semaphore))
+            pthread_cond_init(cond, NULL);
+        MutexRelease(thread_sem);
+    }
 
     task = FindTask(NULL);
     if (abstime) {
@@ -234,7 +282,9 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
     signal = AllocSignal(-1);
     if (signal == -1) {
         signal = SIGB_COND_FALLBACK;
-        SetSignal(SIGF_COND_FALLBACK, 0);
+        /* Clear the fallback signal bit. SetSignal(0, mask) clears;
+         * previously had reversed args SetSignal(mask, 0) which is a no-op. */
+        SetSignal(0, SIGF_COND_FALLBACK);
     }
     waiter.sigbit = signal;
     sigs |= 1 << waiter.sigbit;
@@ -245,7 +295,19 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
     // wait for the condition to be signalled or the timeout
     mutex->incond++;
     pthread_mutex_unlock(mutex);
+
+    // Push cancellation cleanup to remove waiter node if thread is cancelled during Wait
+    CondWaitCleanup cleanup_ctx;
+    cleanup_ctx.cond = cond;
+    cleanup_ctx.mutex = mutex;
+    cleanup_ctx.waiter = &waiter;
+    cleanup_ctx.timerio = abstime ? (struct IORequest *) &timerio : NULL;
+    pthread_cleanup_push(CondWaitCleanupHandler, &cleanup_ctx);
+
     sigs = Wait(sigs);
+
+    pthread_cleanup_pop(0); // don't execute — we handle cleanup below
+
     pthread_mutex_lock(mutex);
     mutex->incond--;
     // remove the node from the list
@@ -286,9 +348,13 @@ _pthread_cond_broadcast(pthread_cond_t *cond, BOOL onlyfirst) {
     if (cond == NULL)
         return EINVAL;
 
-    // initialize static conditions
-    if (SemaphoreIsInvalid(cond->semaphore))
-        pthread_cond_init(cond, NULL);
+    // initialize static conditions (double-check under lock)
+    if (SemaphoreIsInvalid(cond->semaphore)) {
+        MutexObtain(thread_sem);
+        if (SemaphoreIsInvalid(cond->semaphore))
+            pthread_cond_init(cond, NULL);
+        MutexRelease(thread_sem);
+    }
 
     // signal the waiting threads
     ObtainSemaphore(cond->semaphore);
@@ -381,7 +447,9 @@ void __pthread_exit_func(void) {
             while (inf->task)
                 Delay(1);
         } else {
-            if (inf->status == THREAD_STATE_RUNNING)
+            /* Join any non-idle joinable thread, not just RUNNING.
+             * Threads in JOINING/WAITING/TERMINATING states also need cleanup. */
+            if (inf->status != THREAD_STATE_IDLE)
                 pthread_join(i, NULL);
         }
     }

--- a/library/pthread/pthread_cancel.c
+++ b/library/pthread/pthread_cancel.c
@@ -43,23 +43,45 @@ pthread_cancel(pthread_t thread) {
 
     inf = GetThreadInfo(thread);
 
-    if (inf == NULL || inf->parent == NULL || inf->canceled == TRUE)
+    if (inf == NULL)
         return ESRCH;
+
+    /* Hold thread_sem while reading/writing ThreadInfo fields.
+     * Without this lock, the target thread could exit between our
+     * validation checks and the Signal() call, leaving inf->task NULL
+     * which would crash Signal(NULL, mask). */
+    MutexObtain(thread_sem);
+
+    if (inf->task == NULL || inf->status == THREAD_STATE_IDLE) {
+        MutexRelease(thread_sem);
+        return ESRCH;
+    }
+
+    if (inf->canceled == TRUE) {
+        MutexRelease(thread_sem);
+        return ESRCH;
+    }
 
     inf->canceled = TRUE;
 
-    // we might have to cancel the thread immediately
-    if (inf->canceltype == PTHREAD_CANCEL_ASYNCHRONOUS && inf->cancelstate == PTHREAD_CANCEL_ENABLE) {
-        struct Task *task = FindTask(NULL);
-
-        if ((struct Task *) inf->task == task)
-            pthread_testcancel(); // cancel ourselves
-        else
-            Signal((struct Task *) inf->task, inf->cancel_signal_mask); // trigger the exception handler
-    } else {
-        // for the timed waits
-        Signal((struct Task *) inf->task, inf->cancel_signal_mask);
+    /* Check if we are cancelling ourselves */
+    struct Task *self = FindTask(NULL);
+    if ((struct Task *)inf->task == self) {
+        MutexRelease(thread_sem);
+        /* Cancel ourselves — must call testcancel outside the lock
+         * because it may call pthread_exit which longjmps. */
+        if (inf->canceltype == PTHREAD_CANCEL_ASYNCHRONOUS &&
+            inf->cancelstate == PTHREAD_CANCEL_ENABLE)
+            pthread_testcancel();
+        return 0;
     }
+
+    /* Signal the target thread's cancel signal to wake it from any
+     * blocking wait (timed or otherwise). */
+    if (inf->cancel_signal_mask != 0)
+        Signal((struct Task *)inf->task, inf->cancel_signal_mask);
+
+    MutexRelease(thread_sem);
 
     return 0;
 }

--- a/library/pthread/pthread_create.c
+++ b/library/pthread/pthread_create.c
@@ -123,18 +123,20 @@ StarterFunc() {
 
 	ReplyMsg(&newThreadMessage->message);
 
-    /* Allocate signals AFTER ReplyMsg */
-    if (!inf->detached) {
-	    inf->cancel_signal = AllocSignal(-1);
-    	if (inf->cancel_signal == -1) {
-    		inf->cancel_signal_mask = SIGBREAKF_CTRL_C;
-    		D(("StarterFunc: %s AllocSignal cancel failed, fallback SIGBREAKF_CTRL_C\n", inf->name));
-    	} else {
-    		inf->cancel_signal_mask = 1L << inf->cancel_signal;
-    		D(("StarterFunc: %s allocated cancel signal %d mask 0x%lx\n", inf->name, inf->cancel_signal, (unsigned long)inf->cancel_signal_mask));
-    	}
+    /* Allocate cancel signal for ALL threads (joinable and detached).
+     * Previously this was inside the if(!detached) block, so detached
+     * threads could not be cancelled (Signal(task, 0) is a no-op). */
+    inf->cancel_signal = AllocSignal(-1);
+    if (inf->cancel_signal == -1) {
+        inf->cancel_signal_mask = SIGBREAKF_CTRL_C;
+        D(("StarterFunc: %s AllocSignal cancel failed, fallback SIGBREAKF_CTRL_C\n", inf->name));
+    } else {
+        inf->cancel_signal_mask = 1L << inf->cancel_signal;
+        D(("StarterFunc: %s allocated cancel signal %d mask 0x%lx\n", inf->name, inf->cancel_signal, (unsigned long)inf->cancel_signal_mask));
+    }
 
-        /* Allocate join signal */
+    if (!inf->detached) {
+        /* Allocate join signal (only needed for joinable threads) */
         inf->join_signal = AllocSignal(-1);
         if (inf->join_signal == -1) {
             inf->join_signal_mask = SIGF_PARENT;
@@ -200,6 +202,19 @@ StarterFunc() {
     /* If we had swapped the stack, restore it */
     if (stackSwapped)
         StackSwap(&stack);
+
+    /* Free our allocated signals in our own task context (before exit).
+     * AmigaOS FreeSignal operates on the calling task's signal set, so
+     * these must be freed here, not from pthread_join's context.
+     * Previously signals were never freed, leaking bits on every thread exit. */
+    if (inf->cancel_signal != -1 && inf->cancel_signal != SIGBREAKB_CTRL_C) {
+        FreeSignal(inf->cancel_signal);
+        inf->cancel_signal = -1;
+    }
+    if (inf->join_signal != -1 && inf->join_signal != SIGB_PARENT) {
+        FreeSignal(inf->join_signal);
+        inf->join_signal = -1;
+    }
 
     /* NOW acquire thread_sem to atomically set DESTRUCT and search for joiner */
     MutexObtain(thread_sem);

--- a/library/pthread/pthread_detach.c
+++ b/library/pthread/pthread_detach.c
@@ -43,19 +43,28 @@ pthread_detach(pthread_t thread) {
 
     inf = GetThreadInfo(thread);
 
-    if (inf == NULL || inf->task == NULL)
+    if (inf == NULL)
         return ESRCH;
 
-    if (inf->detached)
+    /* Hold thread_sem while reading/writing ThreadInfo fields to prevent
+     * races with concurrent thread exit modifying the same slot. Without
+     * this lock, inf->task could become NULL between our check and the
+     * write to inf->detached. */
+    MutexObtain(thread_sem);
+
+    if (inf->task == NULL || inf->status == THREAD_STATE_IDLE) {
+        MutexRelease(thread_sem);
+        return ESRCH;
+    }
+
+    if (inf->detached) {
+        MutexRelease(thread_sem);
         return EINVAL;
+    }
 
     inf->detached = TRUE;
 
-    /* Note: we do NOT call FreeSignal here because the cancel_signal
-     * was allocated by the target thread (in StarterFunc), and on AmigaOS
-     * FreeSignal operates on the calling task's signal set, not the target's.
-     * The signal will be freed when the thread exits and cleans up.
-     */
+    MutexRelease(thread_sem);
 
     return 0;
 }

--- a/library/pthread/pthread_exit.c
+++ b/library/pthread/pthread_exit.c
@@ -43,8 +43,19 @@ pthread_exit(void *value_ptr) {
 	CleanupHandler *handler;
     ThreadInfo *inf = GetThreadInfo(thread);
 	if (thread == 0) {
-		SHOWMSG("pthread_exit: main thread cannot exit via pthread_exit, return\n");
-		return;
+		/* POSIX: pthread_exit from the main thread should terminate the calling
+		 * thread while allowing other threads to continue running, then perform
+		 * process cleanup equivalent to exit(). On AmigaOS we cannot detach the
+		 * main thread, so we run cleanup handlers and call exit(0), which
+		 * triggers __pthread_exit_func to join remaining threads. */
+		inf->ret = value_ptr;
+		while ((handler = (CleanupHandler *)RemTail((struct List *)&inf->cleanup))) {
+			if (handler->routine)
+				handler->routine(handler->arg);
+			free(handler);
+		}
+		exit(0);
+		return; /* unreachable, silences compiler warning */
 	}
 	if (inf->status == THREAD_STATE_TERMINATING || inf->status == THREAD_STATE_DESTRUCT) {
 		/* The target thread is already terminating, cannot exit */

--- a/library/pthread/pthread_getspecific.c
+++ b/library/pthread/pthread_getspecific.c
@@ -40,44 +40,22 @@
 void *
 pthread_getspecific(pthread_key_t key) {
     ThreadInfo *inf;
-    BOOL key_is_valid;
-    void *value = NULL;
-
-    /* NOTE: D() macros disabled in this function to avoid potential deadlock
-     * if debug output somehow calls pthread_getspecific/setspecific while
-     * holding tls_sem mutex */
 
     if (key >= PTHREAD_KEYS_MAX || key < 0)
         return NULL;
 
-    /* Get current thread info */
     inf = GetCurrentThreadInfo();
     if (inf == NULL)
         return NULL;
 
-    /* Check if pthread library is still initialized (tls_sem not NULL) */
-    /* This can happen if called from destructors after __pthread_exit_func */
-    if (tls_sem == NULL)
+    /* No global lock needed: tlsvalues[] is per-thread private data, only
+     * accessed by the owning thread. Reading tlskeys[key].used without a
+     * lock is a benign race per POSIX (key_delete from another thread).
+     * The previous implementation serialized ALL getspecific/setspecific
+     * calls through tls_sem, which is a scalability bottleneck and violates
+     * POSIX async-signal-safety requirements for pthread_getspecific. */
+    if (!tlskeys[key].used)
         return NULL;
 
-    /* Use global lock to protect the entire operation */
-    /* This prevents race with pthread_key_delete */
-    MutexObtain(tls_sem);
-
-    /* Double-check tlskeys is still valid after acquiring lock */
-    /* It could have been freed by __pthread_exit_func */
-    if (tlskeys == NULL) {
-        MutexRelease(tls_sem);
-        return NULL;
-    }
-
-    /* Check if key is valid INSIDE the lock */
-    if (tlskeys[key].used) {
-        /* Read from tlsvalues INSIDE the lock to prevent race with key_delete */
-        value = inf->tlsvalues[key];
-    }
-
-    MutexRelease(tls_sem);
-
-    return value;
+    return inf->tlsvalues[key];
 }

--- a/library/pthread/pthread_key_delete.c
+++ b/library/pthread/pthread_key_delete.c
@@ -56,6 +56,12 @@ pthread_key_delete(pthread_key_t key) {
     tls->used = FALSE;
     tls->destructor = NULL;
 
+    /* Clear stale TLS values for this key across all threads.
+     * Without this, a subsequently reused key slot exposes dangling
+     * pointers from previous use via pthread_getspecific(). */
+    for (int i = 0; i < PTHREAD_THREADS_MAX; i++)
+        threads[i].tlsvalues[key] = NULL;
+
     MutexRelease(tls_sem);
 
     return 0;

--- a/library/pthread/pthread_kill.c
+++ b/library/pthread/pthread_kill.c
@@ -41,25 +41,41 @@ int
 pthread_kill(pthread_t thread, int sig) {
     ThreadInfo *inf = GetThreadInfo(thread);
 
-    /* Validate thread exists and is active */
-    if (inf == NULL || inf->task == NULL)
-        return ESRCH;
-
-    if (inf->status == THREAD_STATE_IDLE ||
-        inf->status == THREAD_STATE_DESTRUCT ||
-        inf->status == THREAD_STATE_TERMINATED)
+    if (inf == NULL)
         return ESRCH;
 
     /* Validate signal number */
     if (sig < 0 || sig >= NSIG)
         return EINVAL;
 
-    /* sig == 0: just check if thread exists (POSIX) */
-    if (sig == 0)
-        return 0;
+    /* Hold thread_sem to prevent inf->task from being cleared by concurrent exit */
+    MutexObtain(thread_sem);
 
-    /* Send the signal as an AmigaOS signal bit to the target task */
-    Signal((struct Task *)inf->task, 1 << sig);
+    /* Validate thread is active */
+    if (inf->task == NULL ||
+        inf->status == THREAD_STATE_IDLE ||
+        inf->status == THREAD_STATE_DESTRUCT ||
+        inf->status == THREAD_STATE_TERMINATED) {
+        MutexRelease(thread_sem);
+        return ESRCH;
+    }
+
+    /* sig == 0: just check if thread exists (POSIX) */
+    if (sig == 0) {
+        MutexRelease(thread_sem);
+        return 0;
+    }
+
+    /* Use the thread's cancel signal for cancellation (SIGCANCEL-like),
+     * otherwise use SIGBREAKF_CTRL_C as a generic interrupt.
+     * Direct POSIX-to-AmigaOS signal bit mapping is not meaningful
+     * since AmigaOS signal bits have per-task allocation semantics. */
+    if (inf->cancel_signal_mask != 0)
+        Signal((struct Task *)inf->task, inf->cancel_signal_mask);
+    else
+        Signal((struct Task *)inf->task, SIGBREAKF_CTRL_C);
+
+    MutexRelease(thread_sem);
 
     return 0;
 }

--- a/library/pthread/pthread_mutex_destroy.c
+++ b/library/pthread/pthread_mutex_destroy.c
@@ -50,8 +50,14 @@ pthread_mutex_destroy(pthread_mutex_t *mutex) {
         return EBUSY;
     }
 
-    MutexRelease(mutex->mutex);
-    FreeSysObject(ASOT_MUTEX, mutex->mutex);
+    /* Save and NULL out the mutex pointer while still holding the lock,
+     * then release and free. This prevents another thread from obtaining
+     * the mutex between release and free. */
+    APTR mtx = mutex->mutex;
+    mutex->mutex = NULL;
+    mutex->owner = NULL;
+    MutexRelease(mtx);
+    FreeSysObject(ASOT_MUTEX, mtx);
 
     memset(mutex, 0, sizeof(pthread_mutex_t));
 

--- a/library/pthread/pthread_mutex_lock.c
+++ b/library/pthread/pthread_mutex_lock.c
@@ -47,14 +47,22 @@ pthread_mutex_lock(pthread_mutex_t *mutex) {
         return EINVAL;
     }
 
+    /* Double-checked locking for PTHREAD_MUTEX_INITIALIZER lazy init.
+     * Without thread_sem, two threads racing here both see mutex==NULL,
+     * both call init, leaking the first allocation and breaking exclusion. */
     if (mutex->mutex == NULL) {
         SHOWMSG("mutex was not initalized. Initialize it");
-        int ret = _pthread_mutex_init(mutex, NULL, TRUE);
-        if (ret != 0) {
-            SHOWMSG("Cannot initialize mutex");
-            LEAVE();
-            return EINVAL;
+        MutexObtain(thread_sem);
+        if (mutex->mutex == NULL) {
+            int ret = _pthread_mutex_init(mutex, NULL, TRUE);
+            if (ret != 0) {
+                MutexRelease(thread_sem);
+                SHOWMSG("Cannot initialize mutex");
+                LEAVE();
+                return EINVAL;
+            }
         }
+        MutexRelease(thread_sem);
     }
 
 	// ERRORCHECK mutexes return EDEADLK instead of deadlocking

--- a/library/pthread/pthread_mutex_timedlock.c
+++ b/library/pthread/pthread_mutex_timedlock.c
@@ -51,7 +51,6 @@ static void timespec_sub(struct timespec *ts1, const struct timespec *ts2, const
 int
 pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec *abstime) {
     int result;
-    struct _clib4 *__clib4 = __CLIB4;
 
     if (mutex == NULL)
         return EINVAL;
@@ -85,26 +84,34 @@ pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec *abstime) 
         return ETIMEDOUT;
     }
 
-    MutexObtain(timerMutex);
+    // Use stack-local timer resources (thread-safe, no global bottleneck)
+    struct MsgPort timerPort;
+    struct TimeRequest timerIO;
+    struct Task *task = FindTask(NULL);
 
-    uint32 sigMask = 1L << timedTimerPort->mp_SigBit;
+    if (!OpenTimerDevice((struct IORequest *) &timerIO, &timerPort, task)) {
+        CloseTimerDevice((struct IORequest *) &timerIO);
+        return EINVAL;
+    }
 
-    timedTimerIO->Request.io_Command = TR_ADDREQUEST;
-    timedTimerIO->Request.io_Flags = 0;
-    TIMESPEC_TO_OLD_TIMEVAL(&timedTimerIO->Time, &timeout);
+    uint32 sigMask = 1L << timerPort.mp_SigBit;
+
+    timerIO.Request.io_Command = TR_ADDREQUEST;
+    timerIO.Request.io_Flags = 0;
+    TIMESPEC_TO_OLD_TIMEVAL(&timerIO.Time, &timeout);
 
     SetSignal(0, sigMask);
-    SendIO((struct IORequest *) timedTimerIO);
+    SendIO((struct IORequest *) &timerIO);
 
     result = MutexAttemptWithSignal(mutex->mutex, sigMask);
 
     // Abort timer if we got the lock
     if (!(result & sigMask)) {
-        AbortIO((struct IORequest *) timedTimerIO);
-        WaitIO((struct IORequest *) timedTimerIO);
+        AbortIO((struct IORequest *) &timerIO);
+        WaitIO((struct IORequest *) &timerIO);
     }
 
-    MutexRelease(timerMutex);
+    CloseTimerDevice((struct IORequest *) &timerIO);
 
     if (result & sigMask) {
         result = ETIMEDOUT;

--- a/library/pthread/pthread_mutex_trylock.c
+++ b/library/pthread/pthread_mutex_trylock.c
@@ -42,10 +42,19 @@ pthread_mutex_trylock(pthread_mutex_t *mutex) {
     if (mutex == NULL)
         return EINVAL;
 
+    /* Double-checked locking for PTHREAD_MUTEX_INITIALIZER lazy init.
+     * Without thread_sem, two threads racing here both see mutex==NULL,
+     * both call init, leaking the first allocation and breaking exclusion. */
     if (mutex->mutex == NULL) {
-        int ret = _pthread_mutex_init(mutex, NULL, TRUE);
-        if (ret != 0)
-            return EINVAL;
+        MutexObtain(thread_sem);
+        if (mutex->mutex == NULL) {
+            int ret = _pthread_mutex_init(mutex, NULL, TRUE);
+            if (ret != 0) {
+                MutexRelease(thread_sem);
+                return EINVAL;
+            }
+        }
+        MutexRelease(thread_sem);
     }
 
 	if (mutex->kind != PTHREAD_MUTEX_RECURSIVE && MutexIsMine(mutex))

--- a/library/pthread/pthread_mutex_unlock.c
+++ b/library/pthread/pthread_mutex_unlock.c
@@ -42,17 +42,16 @@ pthread_mutex_unlock(pthread_mutex_t *mutex) {
     if (mutex == NULL)
         return EINVAL;
 
-    if (mutex->mutex == NULL) {
-        int ret = _pthread_mutex_init(mutex, NULL, TRUE);
-        if (ret != 0)
-            return EINVAL;
-    }
+    /* An uninitialized mutex should not be lazily initialized during unlock.
+     * Unlocking a never-locked mutex is undefined behavior per POSIX. */
+    if (mutex->mutex == NULL)
+        return EINVAL;
 
-	if (mutex->kind != PTHREAD_MUTEX_NORMAL && !MutexIsMine(mutex))
-		return EPERM;
+    if (mutex->kind != PTHREAD_MUTEX_NORMAL && !MutexIsMine(mutex))
+        return EPERM;
 
-	mutex->owner = NULL;
-	MutexRelease(mutex->mutex);
+    mutex->owner = NULL;
+    MutexRelease(mutex->mutex);
 
     return 0;
 }

--- a/library/pthread/pthread_rwlock_rdlock.c
+++ b/library/pthread/pthread_rwlock_rdlock.c
@@ -44,9 +44,13 @@ pthread_rwlock_rdlock(pthread_rwlock_t *lock) {
 
     pthread_testcancel();
 
-    // initialize static rwlocks
-    if (SemaphoreIsInvalid(lock->semaphore))
-        pthread_rwlock_init(lock, NULL);
+    // initialize static rwlocks (double-check under lock)
+    if (SemaphoreIsInvalid(lock->semaphore)) {
+        MutexObtain(thread_sem);
+        if (SemaphoreIsInvalid(lock->semaphore))
+            pthread_rwlock_init(lock, NULL);
+        MutexRelease(thread_sem);
+    }
 
     // "Results are undefined if the calling thread holds a write lock on rwlock at the time the call is made."
     /*

--- a/library/pthread/pthread_rwlock_tryrdlock.c
+++ b/library/pthread/pthread_rwlock_tryrdlock.c
@@ -44,9 +44,13 @@ pthread_rwlock_tryrdlock(pthread_rwlock_t *lock) {
     if (lock == NULL)
         return EINVAL;
 
-    // initialize static rwlocks
-    if (SemaphoreIsInvalid(lock->semaphore))
-        pthread_rwlock_init(lock, NULL);
+    // initialize static rwlocks (double-check under lock)
+    if (SemaphoreIsInvalid(lock->semaphore)) {
+        MutexObtain(thread_sem);
+        if (SemaphoreIsInvalid(lock->semaphore))
+            pthread_rwlock_init(lock, NULL);
+        MutexRelease(thread_sem);
+    }
 
     ret = AttemptSemaphoreShared(lock->semaphore);
 

--- a/library/pthread/pthread_rwlock_trywrlock.c
+++ b/library/pthread/pthread_rwlock_trywrlock.c
@@ -44,9 +44,13 @@ pthread_rwlock_trywrlock(pthread_rwlock_t *lock) {
     if (lock == NULL)
         return EINVAL;
 
-    // initialize static rwlocks
-    if (SemaphoreIsInvalid(lock->semaphore))
-        pthread_rwlock_init(lock, NULL);
+    // initialize static rwlocks (double-check under lock)
+    if (SemaphoreIsInvalid(lock->semaphore)) {
+        MutexObtain(thread_sem);
+        if (SemaphoreIsInvalid(lock->semaphore))
+            pthread_rwlock_init(lock, NULL);
+        MutexRelease(thread_sem);
+    }
 
     ret = AttemptSemaphore(lock->semaphore);
 

--- a/library/pthread/pthread_rwlock_unlock.c
+++ b/library/pthread/pthread_rwlock_unlock.c
@@ -49,7 +49,9 @@ pthread_rwlock_unlock(pthread_rwlock_t *lock) {
     //if (!SemaphoreIsMine(&lock->semaphore))
     // if no one has obtained the semaphore don't unlock the rwlock
     // this can be a leap of faith because we don't maintain a separate list of readers
-    if (((struct SignalSemaphore *)lock->semaphore)->ss_NestCount < 1)
+    /* Use volatile cast to prevent compiler from caching ss_NestCount
+     * in a register — it can be modified by other threads. */
+    if (((volatile struct SignalSemaphore *)lock->semaphore)->ss_NestCount < 1)
         return EPERM;
 
     ReleaseSemaphore(lock->semaphore);

--- a/library/pthread/pthread_rwlock_wrlock.c
+++ b/library/pthread/pthread_rwlock_wrlock.c
@@ -44,9 +44,13 @@ pthread_rwlock_wrlock(pthread_rwlock_t *lock) {
 
     pthread_testcancel();
 
-    // initialize static rwlocks
-    if (SemaphoreIsInvalid(lock->semaphore))
-        pthread_rwlock_init(lock, NULL);
+    // initialize static rwlocks (double-check under lock)
+    if (SemaphoreIsInvalid(lock->semaphore)) {
+        MutexObtain(thread_sem);
+        if (SemaphoreIsInvalid(lock->semaphore))
+            pthread_rwlock_init(lock, NULL);
+        MutexRelease(thread_sem);
+    }
 
     if (SemaphoreIsMine(lock->semaphore))
         return EDEADLK;

--- a/library/pthread/pthread_self.c
+++ b/library/pthread/pthread_self.c
@@ -44,8 +44,11 @@ pthread_self(void) {
 
     thread = GetThreadId(task);
 
+    /* Return -1 (not 0) for unknown tasks. Returning 0 would alias with
+     * the main thread's ID, causing operations on "self" to corrupt the
+     * main thread's ThreadInfo. */
     if (thread == PTHREAD_THREADS_MAX)
-        return 0;
+        return (pthread_t)-1;
 
     return thread;
 }

--- a/library/pthread/pthread_setspecific.c
+++ b/library/pthread/pthread_setspecific.c
@@ -40,46 +40,24 @@
 int
 pthread_setspecific(pthread_key_t key, const void *value) {
     ThreadInfo *inf;
-    BOOL key_is_valid;
-
-    /* NOTE: D() macros disabled in this function to avoid potential deadlock
-     * if debug output somehow calls pthread_getspecific/setspecific while
-     * holding tls_sem mutex */
 
     if (key >= PTHREAD_KEYS_MAX || key < 0)
         return EINVAL;
 
-    /* Get current thread info - must be valid */
     inf = GetCurrentThreadInfo();
     if (inf == NULL)
         return EINVAL;
 
-    /* Check if pthread library is still initialized (tls_sem not NULL) */
-    /* This can happen if called from destructors after __pthread_exit_func */
-    if (tls_sem == NULL)
+    /* No global lock needed: tlsvalues[] is per-thread private data, only
+     * accessed by the owning thread. Reading tlskeys[key].used without a
+     * lock is a benign race per POSIX (key_delete from another thread).
+     * The previous implementation serialized ALL getspecific/setspecific
+     * calls through tls_sem, which is a scalability bottleneck and violates
+     * POSIX async-signal-safety requirements for pthread_getspecific. */
+    if (!tlskeys[key].used)
         return EINVAL;
 
-    /* Use global lock to protect the entire operation */
-    /* This prevents race with pthread_key_delete */
-    MutexObtain(tls_sem);
-
-    /* Double-check tlskeys is still valid after acquiring lock */
-    /* It could have been freed by __pthread_exit_func */
-    if (tlskeys == NULL) {
-        MutexRelease(tls_sem);
-        return EINVAL;
-    }
-
-    /* Check if key is valid INSIDE the lock */
-    if (!tlskeys[key].used) {
-        MutexRelease(tls_sem);
-        return EINVAL;
-    }
-
-    /* Write to tlsvalues INSIDE the lock to prevent race with key_delete */
     inf->tlsvalues[key] = (void *) value;
-
-    MutexRelease(tls_sem);
 
     return 0;
 }

--- a/library/pthread/pthread_testcancel.c
+++ b/library/pthread/pthread_testcancel.c
@@ -48,5 +48,8 @@ pthread_testcancel(void) {
     if (inf && inf->canceled && (inf->cancelstate == PTHREAD_CANCEL_ENABLE))
         pthread_exit(PTHREAD_CANCELED);
 
-    SetSignal(inf->cancel_signal_mask, 0);
+    /* SetSignal(newSignals=0, signalSet=mask): clears the cancel signal bit.
+     * Previously had reversed arguments SetSignal(mask, 0) which is a no-op
+     * (signalSet=0 means no bits are modified). */
+    SetSignal(0, inf->cancel_signal_mask);
 }


### PR DESCRIPTION
Fixes 23 issues across the pthread implementation:

- Fix reversed SetSignal arguments in 3 locations (testcancel, common.c, pthread.c) — SetSignal(mask, 0) is a no-op, corrected to SetSignal(0, mask)
- Fix stack MsgPort use-after-free in _pthread_obtain_sema_timed
- Fix detached threads unable to be cancelled (cancel_signal in wrong scope)
- Add double-checked locking for all static initializer lazy-init paths (mutex lock/trylock, rwlock rd/wr/tryrd/trywr, cond_timedwait, cond_broadcast)
- Add cancellation cleanup handler for cond_wait (dangling waiter node crash)
- Fix signal bit leak in StarterFunc (FreeSignal before thread exit)
- Replace global timer in pthread_mutex_timedlock with stack-local resources
- Fix pthread_self returning 0 for unknown tasks (aliases main thread)
- Rewrite pthread_kill with proper locking and signal dispatch
- Fix TOCTOU race in pthread_mutex_destroy
- Add ENOMEM check in _pthread_mutex_init
- Make canceled field volatile in ThreadInfo
- Clear stale TLS values on key deletion
- Remove global lock serialization from getspecific/setspecific
- Fix pthread_exit from main thread (run cleanup + exit per POSIX)
- Add volatile cast for ss_NestCount in rwlock_unlock
- Add thread_sem locking to pthread_detach and pthread_cancel
- Return EINVAL from pthread_mutex_unlock on uninitialized mutex
- Fix shutdown to join all non-idle threads, not just RUNNING

All changes include inline comments explaining the rationale. Builds clean with -Werror on ppc-amigaos-gcc 11.