### PR TITLE
Wmem fixes

### DIFF
--- a/library/c.lib_rev.h
+++ b/library/c.lib_rev.h
@@ -2,7 +2,7 @@
 #define REVISION		1
 #define SUBREVISION		0
 
-#define DATE			"29.01.2026"
+#define DATE			"09.03.2026"
 #define VERS			"clib4.library 2.1"
-#define VSTRING			"clib4.library 2.1 (29.01.2026)\r\n"
-#define VERSTAG			"\0$VER: clib4.library 2.1-ab40f98 (29.01.2026)"
+#define VSTRING			"clib4.library 2.1 (09.03.2026)\r\n"
+#define VERSTAG			"\0$VER: clib4.library 2.1-ab40f98 (09.03.2026)"

--- a/library/wmem/wmem_allocator_block_fast.c
+++ b/library/wmem/wmem_allocator_block_fast.c
@@ -91,7 +91,7 @@ static void *
 wmem_block_fast_alloc(void *private_data, const size_t size, int32_t alignment) {
     wmem_block_fast_allocator_t *allocator = (wmem_block_fast_allocator_t *) private_data;
     wmem_block_fast_chunk_t *chunk;
-    int32_t real_size;
+    size_t real_size;
     uint32_t real_pos;
 
 #ifdef MEMORY_DEBUG
@@ -172,6 +172,7 @@ wmem_block_fast_realloc(void *private_data, void *ptr, const size_t size, int32_
 #endif
 
     void *newptr = wmem_block_fast_alloc(private_data, size, alignment);
+    if (newptr == NULL) return NULL;
     memcpy(newptr, ptr, chunk->size);
 
     if (chunk->jumbo) {
@@ -211,9 +212,10 @@ wmem_block_fast_free_all(void *private_data) {
     cur = allocator->block_list;
 
     if (cur) {
-        cur->pos = WMEM_BLOCK_HEADER_SIZE;
+        cur->pos = (uint32_t)cur + WMEM_BLOCK_HEADER_SIZE;
         nxt = cur->next;
         cur->next = NULL;
+        allocator->block_list = cur;
         cur = nxt;
     }
 
@@ -225,7 +227,6 @@ wmem_block_fast_free_all(void *private_data) {
         freed_amount += WMEM_BLOCK_SIZE;
 #endif
     }
-    allocator->block_list = NULL;
 
     /* now do the jumbo blocks, freeing all of them */
     cur_jum = allocator->jumbo_list;

--- a/library/wmem/wmem_allocator_strict.c
+++ b/library/wmem/wmem_allocator_strict.c
@@ -155,7 +155,7 @@ wmem_strict_realloc(void *private_data, void *ptr, const size_t size, int32_t al
     block = WMEM_DATA_TO_BLOCK((wmem_strict_allocator_t *) private_data, ptr);
 
     /* create a new block */
-    new_ptr = wmem_strict_alloc(private_data, size, 2);
+    new_ptr = wmem_strict_alloc(private_data, size, alignment);
 
     /* copy from the old block to the new */
     if (block->data_len > size) {

--- a/library/wmem/wmem_array.c
+++ b/library/wmem/wmem_array.c
@@ -166,17 +166,17 @@ wmem_array_finalize(wmem_array_t *array) {
 
     if (array->null_terminated) {
         uint8_t *new_buf = wmem_alloc(NULL, (array->elem_count + 1) * array->elem_size);
-        memcpy(new_buf, array->buf, array->alloc_count * array->elem_size);
+        memcpy(new_buf, array->buf, array->elem_count * array->elem_size);
         memset(new_buf + array->elem_size * array->elem_count, 0, array->elem_size);
         wmem_free(NULL, array->buf);
         array->buf = new_buf;
     }
 
-    // void *ret = wmem_realloc(array->allocator, array->buf, used_size);
+    void *ret = array->buf;
 
     wmem_free(array->allocator, array);
 
-    return NULL; //ret;
+    return ret;
 }
 
 void

--- a/library/wmem/wmem_core.c
+++ b/library/wmem/wmem_core.c
@@ -313,12 +313,12 @@ wmem_init(void) {
         do_override = true;
         if (strncmp(override_env, "simple", strlen("simple")) == 0) {
             override_type = WMEM_ALLOCATOR_SIMPLE;
+        } else if (strncmp(override_env, "block_fast", strlen("block_fast")) == 0) {
+            override_type = WMEM_ALLOCATOR_BLOCK_FAST;
         } else if (strncmp(override_env, "block", strlen("block")) == 0) {
             override_type = WMEM_ALLOCATOR_BLOCK;
         } else if (strncmp(override_env, "strict", strlen("strict")) == 0) {
             override_type = WMEM_ALLOCATOR_STRICT;
-        } else if (strncmp(override_env, "block_fast", strlen("block_fast")) == 0) {
-            override_type = WMEM_ALLOCATOR_BLOCK_FAST;
         } else {
             SHOWMSG("Unrecognized wmem override");
             do_override = false;


### PR DESCRIPTION
wmem: fix 8 bugs across 4 files

wmem_array.c:
- wmem_array_finalize: fix heap buffer overflow; memcpy was copying
  alloc_count (capacity) bytes into a buffer sized for elem_count only
- wmem_array_finalize: fix function always returning NULL and leaking
  the buffer; now properly returns the finalized buffer pointer

wmem_allocator_block_fast.c:
- wmem_block_fast_free_all: fix 2MB memory leak; first block was saved
  but then discarded by unconditional block_list = NULL
- wmem_block_fast_free_all: fix wrong pos reset; pos is absolute address,
  must include block base address (matching wmem_block_fast_new_block)
- wmem_block_fast_alloc: change int32_t real_size to size_t to prevent
  signed overflow on large jumbo allocations
- wmem_block_fast_realloc: add NULL check after alloc before memcpy

wmem_allocator_strict.c:
- wmem_strict_realloc: use caller's alignment parameter instead of
  hardcoded value 2

wmem_core.c:
- wmem_init: move "block_fast" strncmp check before "block" check;
  "block" prefix matched "block_fast" making that branch unreachable