### PR TITLE
Fix SPE build for adtools cross-compilation with GCC 6 and GCC 7 

### DIFF
--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -142,16 +142,26 @@ ifdef USE_TEMPFILES
 endif
 
 ifdef SPE
+	# Default CC/AS for standalone SPE builds using GCC 6.
+	# When CC is passed on the command line (e.g., from adtools cross-build),
+	# these defaults are skipped so the cross-compiler's xgcc is used instead.
+	ifeq ($(origin CC),file)
 	CC := ppc-amigaos-gcc-6.4.0
 	AS := ppc-amigaos-as-6.4.0
+	endif
 	CMATH := -mfpu=dp_lite
 	OUTPUT_LIB = $(BUILD_DIR)/lib/soft-float
 	CFLAGS := $(CFLAGS) -D__SPE__ -msoft-float -mspe -mtune=8540 -mcpu=8540 -mabi=spe -mfloat-gprs=double $(CMATH) -fno-inline-functions -fno-partial-inlining \
 				-fno-align-functions -fno-align-jumps -fno-align-loops -fno-align-labels -fno-inline-small-functions \
 				-fno-indirect-inlining -Wno-overflow -Wno-unused-but-set-variable -Wno-uninitialized #-Wdouble-promotion
 	AFLAGS := $(AFLAGS) -mvrsave -D__SPE__ -mspe -mtune=8540 -mcpu=8540 -mfloat-gprs=double $(CMATH) -Wno-overflow
+	# Filter out warning flags that don't exist in GCC 6. Combined with
+	# -Werror these cause build failures when building SPE via adtools
+	# cross-compilation.
 	CFLAGS := $(filter-out -Wno-cast-function-type, $(CFLAGS))
 	CFLAGS_N := $(filter-out -Wno-cast-function-type, $(CFLAGS_N))
+	CFLAGS := $(filter-out -Wno-stringop-overflow, $(CFLAGS))
+	CFLAGS_N := $(filter-out -Wno-stringop-overflow, $(CFLAGS_N))
 endif
 
 ifdef PROFILE

--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -142,7 +142,7 @@ ifdef USE_TEMPFILES
 endif
 
 ifdef SPE
-	# Default CC/AS for standalone SPE builds using GCC 6.
+	# Default CC/AS for standalone SPE builds (assumes GCC 6 installed).
 	# When CC is passed on the command line (e.g., from adtools cross-build),
 	# these defaults are skipped so the cross-compiler's xgcc is used instead.
 	ifeq ($(origin CC),file)
@@ -155,13 +155,17 @@ ifdef SPE
 				-fno-align-functions -fno-align-jumps -fno-align-loops -fno-align-labels -fno-inline-small-functions \
 				-fno-indirect-inlining -Wno-overflow -Wno-unused-but-set-variable -Wno-uninitialized #-Wdouble-promotion
 	AFLAGS := $(AFLAGS) -mvrsave -D__SPE__ -mspe -mtune=8540 -mcpu=8540 -mfloat-gprs=double $(CMATH) -Wno-overflow
-	# Filter out warning flags that don't exist in GCC 6. Combined with
-	# -Werror these cause build failures when building SPE via adtools
-	# cross-compilation.
+	# Filter out warning flags that don't exist in GCC 6/7. Combined with
+	# -Werror these cause build failures when cross-compiling SPE via
+	# adtools with older GCC versions.
 	CFLAGS := $(filter-out -Wno-cast-function-type, $(CFLAGS))
 	CFLAGS_N := $(filter-out -Wno-cast-function-type, $(CFLAGS_N))
 	CFLAGS := $(filter-out -Wno-stringop-overflow, $(CFLAGS))
 	CFLAGS_N := $(filter-out -Wno-stringop-overflow, $(CFLAGS_N))
+	# Downgrade warnings that GCC 7 is stricter about to non-fatal.
+	# These are harmless on GCC 6 (silently ignored) and GCC 8+ (less strict).
+	CFLAGS += -Wno-error=maybe-uninitialized -Wno-error=implicit-fallthrough
+	CFLAGS_N += -Wno-error=maybe-uninitialized -Wno-error=implicit-fallthrough
 endif
 
 ifdef PROFILE


### PR DESCRIPTION
                                                                                                                                               
  ## Summary                                                                                                                                                                         
  - Guard CC/AS override in SPE block with `$(origin CC)` check so standalone builds still default to `gcc-6.4.0`, but adtools cross-builds use the provided xgcc          - Filter out `-Wno-stringop-overflow` (GCC 7+) and `-Wno-cast-function-type` (GCC 8+) since both flags don't exist in GCC 6 and cause `-Werror` build failures           - Add `-Wno-error=maybe-uninitialized` and `-Wno-error=implicit-fallthrough` to downgrade warnings that GCC 7 is stricter about (harmless on GCC 6 and 8+)    
                                                                                                                                                                         
  ## Problem                                                                                                                                                                                                                                                                                                                                      
  The SPE block in `GNUmakefile.os4` hardcodes `CC := ppc-amigaos-gcc-6.4.0`, which overrides the compiler passed by adtools when building clib4 as part of a              cross-compiler toolchain via `make -f GNUmakefile.os4 CC=... SPE=1`.                                                                                                                                                                         
  Additionally:                                                                                                                                                          
  - `-Wno-cast-function-type` (GCC 8+) and `-Wno-stringop-overflow` (GCC 7+) don't exist in GCC 6 and combined with `-Werror` cause build failures
  - GCC 7 is stricter about `-Wmaybe-uninitialized` and `-Wimplicit-fallthrough` warnings, which combined with `-Werror` cause build failures that don't occur with GCC
  8+                                                                                                                                                                     
                                                                                                                                                                           ## Backwards compatibility                                                                                                                                             
                                                                                                                                                                         
  - Standalone `make SPE=1` builds still default to `gcc-6.4.0`
  - Non-SPE builds are completely unaffected (all changes inside `ifdef SPE`)                                                                                              - The `-Wno-error=` flags are silently ignored by GCC versions that don't have the corresponding warnings