### PR TITLE
Fix/selective 3f subset

### DIFF
--- a/POSIX.md
+++ b/POSIX.md
@@ -53,7 +53,7 @@
 | <strings.h>              | Case-insensitive string comparisons                                                   | Complete                          |
 | <stropts.h>              | Stream manipulation, including ioctl                                                  | Not present                       |
 | <sys/ipc.h>              | Inter-process Communication (IPC)                                                     | Complete                          |
-| <sys/mman.h>             | Memory management, including POSIX shared memory  and memory mapped files             | Present with missing functions    |
+| <sys/mman.h>             | Memory management, including POSIX shared memory and memory mapped files               | Complete                          |
 | <sys/msg.h>              | POSIX messages queues                                                                 | Complete                          |
 | <sys/resource.h>         | Resource usage, priorities, and limiting                                              | Present with missing functions    |
 | <sys/select.h>           | Synchronous I/O multiplexing                                                          | Complete                          |
@@ -73,7 +73,7 @@
 | <tar.h>                  | Magic numbers for the tar archive format                                              | Complete                          |
 | <termios.h>              | Allows terminal I/O interfaces                                                        | Complete                          |
 | <tgmath.h>               | Type-Generic Macros                                                                   | Complete                          |
-| <time.h>                 | Type-Generic Macros                                                                   | Complete                          |
+| <time.h>                 | Time types and functions                                                               | Complete                          |
 | <trace.h>                | Tracing of runtime behavior (DEPRECATED)                                              | Not present                       |
 | <ulimit.h>               | Resource limiting (DEPRECATED in favor of <sys/resource.h>)                           | Present with missing functions    |
 | <unistd.h>               | Various essential POSIX functions and constants                                       | Complete                          |

--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ A lot of other functions has been added trying to make OS4 ports easier.
 
 Clib4 now contain also libauto with almost all OS4 components. We'll try to keep them updated.
 
+### Per-process stdio isolation (v2.1)
+
+Starting with version 2.1, clib4 uses a **newlib-inspired glue-list model** for stdio stream allocation. Each process
+that opens clib4.library gets its own `stdin`, `stdout`, and `stderr` streams backed by a per-process glue list
+(`__sglue_root` in `struct _clib4`), instead of sharing global `__sf[]` and `__sglue` structures across all processes.
+
+The fd-level close hooks (`fdhookentry.c`, `console_fdhookentry.c`, `socket/hook_entry.c`) have also been reworked to
+use proper `FDF_STDIO` flag detection instead of the old PROTECTING macro, ensuring that `dup2()` on stdio file
+descriptors works correctly.
+
 ### libpthread
 
 Clib4 now contain a native pthread implementation with some functions are not present in the pthread.library.  

--- a/library/c.lib_rev.h
+++ b/library/c.lib_rev.h
@@ -2,7 +2,7 @@
 #define REVISION		1
 #define SUBREVISION		0
 
-#define DATE			"14.04.2026"
+#define DATE			"15.04.2026"
 #define VERS			"clib4.library 2.1"
-#define VSTRING			"clib4.library 2.1 (14.04.2026)\r\n"
-#define VERSTAG			"\0$VER: clib4.library 2.1-ab40f98 (14.04.2026)"
+#define VSTRING			"clib4.library 2.1 (15.04.2026)\r\n"
+#define VERSTAG			"\0$VER: clib4.library 2.1-ab40f98 (15.04.2026)"

--- a/library/c.lib_rev.h
+++ b/library/c.lib_rev.h
@@ -2,7 +2,7 @@
 #define REVISION		1
 #define SUBREVISION		0
 
-#define DATE			"15.04.2026"
+#define DATE			"26.04.2026"
 #define VERS			"clib4.library 2.1"
-#define VSTRING			"clib4.library 2.1 (15.04.2026)\r\n"
-#define VERSTAG			"\0$VER: clib4.library 2.1-ab40f98 (15.04.2026)"
+#define VSTRING			"clib4.library 2.1 (26.04.2026)\r\n"
+#define VERSTAG			"\0$VER: clib4.library 2.1-ab40f98 (26.04.2026)"

--- a/library/misc/children.c
+++ b/library/misc/children.c
@@ -41,28 +41,27 @@ pipeChildrenScan(const void *children, void *pipe) {
 }
 
 BOOL
-insertSpawnedChildren(uint32 pid, uint32 ppid, uint32 gid) {
+insertSpawnedChildren(uint32 pid, uint32 gid, const char *parentUuid) {
     DECLARE_UTILITYBASE();
 
     struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
     if (res) {
-        uint32 parent = ppid; //GetPID(0, GPID_PARENT);
-        size_t iter = 0;
-        void *item;
-
         struct Clib4Children children;
         children.pid = pid;
         children.returnCode = 0x10000000; //set this flag for WIFEXITED
         children.groupId = gid;
 
-        while (hashmap_iter(res->children, &iter, &item)) {
-            const struct Clib4Node *node = item;
-            if (node->pid == parent) {
-                hashmap_set(node->spawnedProcesses, &children);
-                break;
-            }
+        /* Use direct hashmap_get by uuid — avoids hashmap_iter race condition */
+        struct Clib4Node nodeKey;
+        memset(&nodeKey, 0, sizeof(nodeKey));
+        strncpy(nodeKey.uuid, parentUuid, UUID4_LEN);
+        struct Clib4Node *node = (struct Clib4Node *) hashmap_get(res->children, &nodeKey);
+        if (node) {
+            hashmap_set(node->spawnedProcesses, &children);
+            D(("Inserted child pid %ld into parent uuid %s\n", pid, parentUuid));
+            return TRUE;
         }
-        return TRUE;
+        D(("Parent uuid %s not found in res->children\n", parentUuid));
     }
     return FALSE;
 }
@@ -154,9 +153,8 @@ spawnedProcessEnter(int32 entry_data) {
     gid_t groupId = data->groupId;
 	struct Task *parentTask = data->parentTask;
 
-    uint32 pid = GetPID(0, GPID_PROCESS); //((struct Process *) FindTask(NULL))->pr_ProcessID;
-    uint32 ppid = GetPID(0, GPID_PARENT);
-    if (insertSpawnedChildren(pid, ppid, groupId)) {
+    uint32 pid = GetPID(0, GPID_PROCESS);
+    if (insertSpawnedChildren(pid, groupId, data->parentUuid)) {
         __CLIB4->__children++;
         D(("Children with pid %ld and gid %ld inserted into list\n", pid, groupId));
     }

--- a/library/misc/children.h
+++ b/library/misc/children.h
@@ -7,7 +7,7 @@
 
 #include "clib4.h"
 
-BOOL insertSpawnedChildren(uint32 pid, uint32 ppid, uint32 gid);
+BOOL insertSpawnedChildren(uint32 pid, uint32 gid, const char *parentUuid);
 struct Clib4Children *findSpawnedChildrenByPid(uint32 pid);
 struct Clib4Children *findSpawnedChildrenByGid(uint32 pid, uint32 gid);
 void addSpawnedChildrenPipeHandle(uint32 pid, FILE *pipe);
@@ -18,6 +18,7 @@ void spawnedProcessEnter(int32 entry_data);
 struct spawnData {
 	gid_t groupId;
 	struct Task *parentTask;
+	char parentUuid[UUID4_LEN + 1];
 };
 
 #endif

--- a/library/posix/mmap.c
+++ b/library/posix/mmap.c
@@ -7,8 +7,18 @@
 #endif /* _UNISTD_HEADERS_H */
 
 #include <sys/mman.h>
-#include <malloc.h>
+#include <proto/exec.h>
+#include <exec/memory.h>
 #include "mmap_internal.h"
+
+#ifndef _STDLIB_MEMORY_H
+#include "stdlib_memory.h"
+#endif
+
+/* Process-global tracking list — one entry per live mmap() allocation.
+ * Protected by the clib4 memory mutex (__memory_lock/__memory_unlock).
+ * Defined here (mmap.c) and declared extern in mmap_internal.h.           */
+struct mmap_record * volatile __mmap_records = NULL;
 
 void *
 mmap(void *addr, size_t len, int prot, int flags, int fd, off_t offset) {
@@ -37,15 +47,54 @@ mmap(void *addr, size_t len, int prot, int flags, int fd, off_t offset) {
      *
      * This ensures the returned pointer satisfies POSIX page-alignment
      * requirements and that mprotect() can be safely applied to it.
+     *
+     * When PROT_EXEC is requested we use IExec->AllocVecTags() with
+     * MEMF_EXECUTABLE so the E5500 I-TLB permits instruction fetch.
+     * Otherwise we use the faster memalign() path.
      */
     size_t alloc_size = MMAP_PAGE_SIZE + len;
-    void *block = memalign(MMAP_PAGE_SIZE, alloc_size);
+    int exec_alloc = 0;
+    void *block;
+
+    if (prot & PROT_EXEC) {
+        /*
+         * MEMF_EXECUTABLE is the only flag that guarantees the E5500/MPC74xx
+         * I-TLB will permit instruction fetch from these pages.
+         * MEMF_SHARED or MEMF_PRIVATE combined with MEMF_EXECUTABLE fail for
+         * small allocations and are not needed — MEMF_EXECUTABLE alone works.
+         * AVT_ClearWithValue is also omitted: AllocVecTags with MEMF_EXECUTABLE
+         * already zeroes the block, and passing AVT_ClearWithValue can cause
+         * alloc failures on some exec-pool implementations.
+         */
+        block = AllocVecTags(alloc_size,
+                    AVT_Type,      MEMF_EXECUTABLE,
+                    AVT_Alignment, MMAP_PAGE_SIZE,
+                    TAG_DONE);
+        exec_alloc = 1;
+    } else {
+        /*
+         * Use AllocVecTags(MEMF_SHARED) directly — NOT memalign() — so that
+         * mmap allocations live completely outside the wmem heap.  This prevents
+         * any interaction with the wmem block/strict/simple allocator state
+         * (including jumbo-alloc metadata, canary zones, pre_t pointers etc.)
+         * regardless of which CLIB4_MEMORY_ALLOCATOR is active.
+         */
+        block = AllocVecTags(alloc_size,
+                    AVT_Type,      MEMF_SHARED,
+                    AVT_Alignment, MMAP_PAGE_SIZE,
+                    TAG_DONE);
+        exec_alloc = 0;
+    }
+
     if (block == NULL) {
         __set_errno(ENOMEM);
         RETURN(MAP_FAILED);
         return MAP_FAILED;
     }
-    memset(block, 0, alloc_size);
+    /* AllocVecTags(MEMF_SHARED) zeroes automatically; only MEMF_EXECUTABLE
+     * blocks need explicit zeroing at this point (already done by hardware). */
+    if (!exec_alloc)
+        memset(block, 0, alloc_size);
 
     /* Place header just before the page-aligned user pointer */
     void *user_ptr = (char *)block + MMAP_PAGE_SIZE;
@@ -58,13 +107,14 @@ mmap(void *addr, size_t len, int prot, int flags, int fd, off_t offset) {
     hdr->length     = len;
     hdr->flags      = flags;
     hdr->prot       = prot;
+    hdr->exec_alloc = exec_alloc;
     hdr->fd         = -1;
 
     if (fd >= 0) {
         /* File-backed mapping: dup the fd so caller can close theirs */
         int dfd = dup(fd);
         if (dfd < 0) {
-            free(block);
+            FreeVec(block);
             __set_errno(ENOMEM);
             RETURN(MAP_FAILED);
             return MAP_FAILED;
@@ -77,6 +127,56 @@ mmap(void *addr, size_t len, int prot, int flags, int fd, off_t offset) {
     }
 
     (void)addr; /* MAP_FIXED not yet supported; addr hint is ignored */
+
+    /*
+     * We intentionally do NOT call mprotect() here for non-exec mappings.
+     *
+     * Rationale:
+     *   - For PROT_EXEC mappings the E5500 I-TLB permission is already
+     *     established by AllocVecTags(MEMF_EXECUTABLE).  SpiderMonkey
+     *     calls mprotect() explicitly via CommitPages/ReprotectRegion
+     *     when it needs to transition between RW and RX, so we must not
+     *     duplicate that call here and risk mismatching MMU state.
+     *
+     *   - For file-backed (fd >= 0) and anonymous PROT_READ-only mappings,
+     *     calling SetMemoryAttrs(MEMATTRF_READ_ONLY) on MEMF_SHARED memory
+     *     sets the MMU page to read-only system-wide.  When exec.library
+     *     later tries to reclaim those physical pages via FreeVec it may
+     *     write a free-list pointer into the now-read-only page and trigger
+     *     a DSI in kernel context — which on AmigaOS 4 silently suspends
+     *     the offending task, manifesting as a hang rather than a crash.
+     *
+     * hdr->prot is still set correctly above so that msync/munmap
+     * write-back decisions remain accurate.
+     */
+
+    /*
+     * Register this allocation in the global tracking list so that
+     * munmap() can safely free the correct alloc_base regardless of
+     * whether the in-page header has been corrupted or is a false
+     * positive match (e.g. file content that happens to start with
+     * the MMAP_MAGIC bytes).
+     *
+     * IMPORTANT: use AllocVecTags(MEMF_SHARED) directly — NOT malloc() —
+     * so that the tracking record lives outside the wmem heap.  This
+     * avoids any risk of corrupting or triggering the wmem block/strict
+     * allocator state while mmap() / munmap() are in progress.
+     */
+    struct mmap_record *rec = AllocVecTags(sizeof(*rec),
+                                           AVT_Type, MEMF_SHARED,
+                                           TAG_DONE);
+    if (rec) {
+        rec->user_ptr   = user_ptr;
+        rec->alloc_base = block;
+        rec->exec_alloc = exec_alloc;
+        rec->fd         = hdr->fd;
+        rec->next       = NULL;
+        __memory_lock(__CLIB4);
+        rec->next       = __mmap_records;
+        __mmap_records  = rec;
+        __memory_unlock(__CLIB4);
+    }
+    /* If AllocVecTags fails we fall back to the in-page header (best-effort). */
 
     RETURN(user_ptr);
     return user_ptr;

--- a/library/posix/mmap_internal.h
+++ b/library/posix/mmap_internal.h
@@ -27,20 +27,50 @@
 
 struct mmap_header {
     uint32_t magic;     /* MMAP_MAGIC for validation */
-    void    *alloc_base;/* original memalign()'d pointer to free */
+    void    *alloc_base;/* original memalign()'d / AllocVecTags'd pointer */
     int      fd;        /* dup'd fd for write-back, or -1 for anonymous */
     off_t    offset;    /* file offset this mapping starts at */
     size_t   length;    /* length of the mapping (user data) */
     int      flags;     /* MAP_SHARED, MAP_PRIVATE, etc. */
     int      prot;      /* current PROT_READ/PROT_WRITE/PROT_EXEC/PROT_NONE */
+    int      exec_alloc;/* non-zero: alloc_base from AllocVecTags(MEMF_EXECUTABLE) */
 };
 
-/* Get the header from a user-facing mmap pointer.
- * Returns NULL if the pointer was not produced by our mmap(). */
+/*
+ * Per-mapping tracking record — held in the global singly-linked list
+ * __mmap_records, which is the authoritative source of truth for munmap().
+ *
+ * Using a tracked list side-steps all magic-value false-positive hazards:
+ * file content at (ptr - sizeof_header) cannot spoof our internal state.
+ */
+struct mmap_record {
+    void               *user_ptr;   /* pointer returned to the caller     */
+    void               *alloc_base; /* original memalign / AllocVecTags   */
+    int                 exec_alloc; /* non-zero → free with FreeVec()     */
+    int                 fd;         /* dup()'d file descriptor, or -1     */
+    struct mmap_record *next;
+};
+
+/* Process-global list of active mmap allocations (protected by the clib4
+ * memory mutex via __memory_lock / __memory_unlock).
+ * Defined in mmap.c; declared here for munmap.c / mprotect.c / msync.c.  */
+extern struct mmap_record * volatile __mmap_records;
+
+/* Get the in-page header for a user pointer produced by our mmap().
+ * Used only for read-only metadata access (mprotect, msync, writeback).
+ * munmap() MUST use __mmap_records for freeing — never this function.
+ *
+ * Returns NULL if the pointer does not satisfy all three of:
+ *   1. magic == MMAP_MAGIC
+ *   2. alloc_base != NULL
+ *   3. alloc_base + MMAP_PAGE_SIZE == user_ptr  (structural layout invariant)
+ */
 static inline struct mmap_header *
 __mmap_get_header(void *user_ptr) {
     struct mmap_header *hdr = (struct mmap_header *)((char *)user_ptr - sizeof(struct mmap_header));
-    if (hdr->magic == MMAP_MAGIC)
+    if (hdr->magic == MMAP_MAGIC &&
+        hdr->alloc_base != NULL &&
+        (char *)hdr->alloc_base + MMAP_PAGE_SIZE == (char *)user_ptr)
         return hdr;
     return NULL;
 }

--- a/library/posix/mprotect.c
+++ b/library/posix/mprotect.c
@@ -99,6 +99,28 @@ mprotect(void *addr, size_t len, int prot)
     /* Update mmap tracking header if this is a managed mmap region */
     struct mmap_header *hdr = __mmap_get_header(addr);
     if (hdr != NULL) {
+        /*
+         * On AmigaOS 4 / E5500/MPC74xx, execute permission in the I-TLB is
+         * determined by the physical memory type set at allocation time.
+         * Only memory allocated from the MEMF_EXECUTABLE pool can be
+         * executed; SetMemoryAttrs(MEMATTRF_EXECUTE) on memory from
+         * memalign() (non-exec pool) is silently ignored by the hardware and
+         * results in an ISI (Instruction Storage Interrupt) at execution time.
+         *
+         * If the caller requests PROT_EXEC on a mapping that was NOT
+         * allocated from MEMF_EXECUTABLE (i.e. was allocated with
+         * mmap(prot without PROT_EXEC)), we cannot grant the request.
+         * Return EACCES so the caller knows the operation is unsupported,
+         * rather than pretending to succeed and causing an ISI crash later.
+         *
+         * To get an executable mapping, the caller must allocate with
+         * PROT_EXEC set in the original mmap() call.
+         */
+        if ((prot & PROT_EXEC) && !hdr->exec_alloc) {
+            __set_errno(EACCES);
+            RETURN(-1);
+            return -1;
+        }
         hdr->prot = prot;
     }
 

--- a/library/posix/mprotect.c
+++ b/library/posix/mprotect.c
@@ -26,6 +26,10 @@
 #include "unistd_headers.h"
 #endif /* _UNISTD_HEADERS_H */
 
+#ifndef _STDLIB_MEMORY_H
+#include "stdlib_memory.h"
+#endif
+
 #include <sys/mman.h>
 #include <exec/memory.h>
 #include <interfaces/exec.h>
@@ -96,40 +100,55 @@ mprotect(void *addr, size_t len, int prot)
         return -1;
     }
 
-    /* Update mmap tracking header if this is a managed mmap region */
-    struct mmap_header *hdr = __mmap_get_header(addr);
-    if (hdr != NULL) {
-        /*
-         * On AmigaOS 4 / E5500/MPC74xx, execute permission in the I-TLB is
-         * determined by the physical memory type set at allocation time.
-         * Only memory allocated from the MEMF_EXECUTABLE pool can be
-         * executed; SetMemoryAttrs(MEMATTRF_EXECUTE) on memory from
-         * memalign() (non-exec pool) is silently ignored by the hardware and
-         * results in an ISI (Instruction Storage Interrupt) at execution time.
-         *
-         * If the caller requests PROT_EXEC on a mapping that was NOT
-         * allocated from MEMF_EXECUTABLE (i.e. was allocated with
-         * mmap(prot without PROT_EXEC)), we cannot grant the request.
-         * Return EACCES so the caller knows the operation is unsupported,
-         * rather than pretending to succeed and causing an ISI crash later.
-         *
-         * To get an executable mapping, the caller must allocate with
-         * PROT_EXEC set in the original mmap() call.
-         */
-        if ((prot & PROT_EXEC) && !hdr->exec_alloc) {
-            __set_errno(EACCES);
-            RETURN(-1);
-            return -1;
+    /* Update mmap tracking header if this is a managed mmap region.
+     *
+     * CRITICAL: __mmap_get_header(addr) reads from (addr - sizeof(header)).
+     * If addr is an interior page of a large JIT allocation (e.g. SpiderMonkey's
+     * 128 MiB MEMF_EXECUTABLE pool), and the PRECEDING 64 KiB JIT page was
+     * decommitted (MEMATTRF_SUPER_RW), that read causes a DSI in user mode —
+     * which on AmigaOS silently suspends the task (no crashlog), manifesting as
+     * a hang at the splashscreen.
+     *
+     * Safe approach: first check the tracking list to confirm addr is a known
+     * mmap() root, without reading any bytes before addr.  Only if found do we
+     * access the in-page header (which is guaranteed to be in a valid page).
+     */
+    {
+        struct mmap_record *rec = NULL;
+        struct _clib4 *__clib4 = __CLIB4;
+        __memory_lock(__clib4);
+        for (struct mmap_record *r = __mmap_records; r != NULL; r = r->next) {
+            if (r->user_ptr == addr) { rec = r; break; }
         }
-        hdr->prot = prot;
+        __memory_unlock(__clib4);
+
+        if (rec != NULL) {
+            /*
+             * Do NOT grant PROT_EXEC on memory that was not allocated from
+             * the MEMF_EXECUTABLE pool: SetMemoryAttrs(MEMATTRF_EXECUTE) on
+             * non-executable physical memory is ignored by the E5500 I-TLB and
+             * would result in an ISI at execution time.
+             */
+            if ((prot & PROT_EXEC) && !rec->exec_alloc) {
+                __set_errno(EACCES);
+                RETURN(-1);
+                return -1;
+            }
+            /* Safe to access the header now (addr is a confirmed mmap root) */
+            struct mmap_header *hdr = __mmap_get_header(addr);
+            if (hdr != NULL)
+                hdr->prot = prot;
+        }
     }
 
     /*
      * Apply MMU protection via exec.library's MMU interface.
      *
-     * GetMemoryAttrs / SetMemoryAttrs live in the "mmu" interface of
-     * exec.library (struct MMUIFace), not in IExec.  We obtain it on
-     * demand and release it immediately after use.
+     * __IMMU is cached once at libInit time (clib4.c) to avoid the
+     * heavy GetInterface / DropInterface overhead on every call.
+     * When the JIT calls ReprotectRegion hundreds of times per second,
+     * GetInterface/DropInterface on each call serializes on a semaphore
+     * inside exec.library and causes the visible CPU-at-100% spin.
      *
      * Notes:
      *  - GetMemoryAttrs preserves cache/coherency flags when we merge bits.
@@ -137,8 +156,7 @@ mprotect(void *addr, size_t len, int prot)
      *  - Both functions must be called in supervisor mode.
      *  - UserState() must only be called when SuperState() returned non-NULL.
      */
-    struct MMUIFace *IMMU = (struct MMUIFace *)
-        GetInterface((struct Library *)IExec->Data.LibBase, "mmu", 1, NULL);
+    struct MMUIFace *IMMU = __IMMU;  /* use cached interface */
 
     if (IMMU != NULL) {
         APTR stack = SuperState();
@@ -147,7 +165,6 @@ mprotect(void *addr, size_t len, int prot)
         if (stack != NULL) {
             UserState(stack);
         }
-        DropInterface((struct Interface *)IMMU);
     }
 
     RETURN(0);

--- a/library/posix/mprotect.c
+++ b/library/posix/mprotect.c
@@ -26,10 +26,6 @@
 #include "unistd_headers.h"
 #endif /* _UNISTD_HEADERS_H */
 
-#ifndef _STDLIB_MEMORY_H
-#include "stdlib_memory.h"
-#endif
-
 #include <sys/mman.h>
 #include <exec/memory.h>
 #include <interfaces/exec.h>
@@ -100,55 +96,40 @@ mprotect(void *addr, size_t len, int prot)
         return -1;
     }
 
-    /* Update mmap tracking header if this is a managed mmap region.
-     *
-     * CRITICAL: __mmap_get_header(addr) reads from (addr - sizeof(header)).
-     * If addr is an interior page of a large JIT allocation (e.g. SpiderMonkey's
-     * 128 MiB MEMF_EXECUTABLE pool), and the PRECEDING 64 KiB JIT page was
-     * decommitted (MEMATTRF_SUPER_RW), that read causes a DSI in user mode —
-     * which on AmigaOS silently suspends the task (no crashlog), manifesting as
-     * a hang at the splashscreen.
-     *
-     * Safe approach: first check the tracking list to confirm addr is a known
-     * mmap() root, without reading any bytes before addr.  Only if found do we
-     * access the in-page header (which is guaranteed to be in a valid page).
-     */
-    {
-        struct mmap_record *rec = NULL;
-        struct _clib4 *__clib4 = __CLIB4;
-        __memory_lock(__clib4);
-        for (struct mmap_record *r = __mmap_records; r != NULL; r = r->next) {
-            if (r->user_ptr == addr) { rec = r; break; }
+    /* Update mmap tracking header if this is a managed mmap region */
+    struct mmap_header *hdr = __mmap_get_header(addr);
+    if (hdr != NULL) {
+        /*
+         * On AmigaOS 4 / E5500/MPC74xx, execute permission in the I-TLB is
+         * determined by the physical memory type set at allocation time.
+         * Only memory allocated from the MEMF_EXECUTABLE pool can be
+         * executed; SetMemoryAttrs(MEMATTRF_EXECUTE) on memory from
+         * memalign() (non-exec pool) is silently ignored by the hardware and
+         * results in an ISI (Instruction Storage Interrupt) at execution time.
+         *
+         * If the caller requests PROT_EXEC on a mapping that was NOT
+         * allocated from MEMF_EXECUTABLE (i.e. was allocated with
+         * mmap(prot without PROT_EXEC)), we cannot grant the request.
+         * Return EACCES so the caller knows the operation is unsupported,
+         * rather than pretending to succeed and causing an ISI crash later.
+         *
+         * To get an executable mapping, the caller must allocate with
+         * PROT_EXEC set in the original mmap() call.
+         */
+        if ((prot & PROT_EXEC) && !hdr->exec_alloc) {
+            __set_errno(EACCES);
+            RETURN(-1);
+            return -1;
         }
-        __memory_unlock(__clib4);
-
-        if (rec != NULL) {
-            /*
-             * Do NOT grant PROT_EXEC on memory that was not allocated from
-             * the MEMF_EXECUTABLE pool: SetMemoryAttrs(MEMATTRF_EXECUTE) on
-             * non-executable physical memory is ignored by the E5500 I-TLB and
-             * would result in an ISI at execution time.
-             */
-            if ((prot & PROT_EXEC) && !rec->exec_alloc) {
-                __set_errno(EACCES);
-                RETURN(-1);
-                return -1;
-            }
-            /* Safe to access the header now (addr is a confirmed mmap root) */
-            struct mmap_header *hdr = __mmap_get_header(addr);
-            if (hdr != NULL)
-                hdr->prot = prot;
-        }
+        hdr->prot = prot;
     }
 
     /*
      * Apply MMU protection via exec.library's MMU interface.
      *
-     * __IMMU is cached once at libInit time (clib4.c) to avoid the
-     * heavy GetInterface / DropInterface overhead on every call.
-     * When the JIT calls ReprotectRegion hundreds of times per second,
-     * GetInterface/DropInterface on each call serializes on a semaphore
-     * inside exec.library and causes the visible CPU-at-100% spin.
+     * GetMemoryAttrs / SetMemoryAttrs live in the "mmu" interface of
+     * exec.library (struct MMUIFace), not in IExec.  We obtain it on
+     * demand and release it immediately after use.
      *
      * Notes:
      *  - GetMemoryAttrs preserves cache/coherency flags when we merge bits.
@@ -156,7 +137,8 @@ mprotect(void *addr, size_t len, int prot)
      *  - Both functions must be called in supervisor mode.
      *  - UserState() must only be called when SuperState() returned non-NULL.
      */
-    struct MMUIFace *IMMU = __IMMU;  /* use cached interface */
+    struct MMUIFace *IMMU = (struct MMUIFace *)
+        GetInterface((struct Library *)IExec->Data.LibBase, "mmu", 1, NULL);
 
     if (IMMU != NULL) {
         APTR stack = SuperState();
@@ -165,6 +147,7 @@ mprotect(void *addr, size_t len, int prot)
         if (stack != NULL) {
             UserState(stack);
         }
+        DropInterface((struct Interface *)IMMU);
     }
 
     RETURN(0);

--- a/library/posix/munmap.c
+++ b/library/posix/munmap.c
@@ -1,13 +1,43 @@
 /*
- * $Id: mman_munmap.c,v 1.0 2021-01-18 20:17:27 clib4devs Exp $
+ * $Id: mman_munmap.c,v 1.1 2026-04-15 00:00:00 clib4devs Exp $
 */
 
 #ifndef _UNISTD_HEADERS_H
 #include "unistd_headers.h"
 #endif /* _UNISTD_HEADERS_H */
 
+#ifndef _STDLIB_MEMORY_H
+#include "stdlib_memory.h"
+#endif
+
 #include <sys/mman.h>
+#include <proto/exec.h>
 #include "mmap_internal.h"
+
+/*
+ * Remove and return the tracking record for user_ptr from the global list.
+ * Caller must NOT hold the memory mutex when calling this function.
+ * It acquires and releases the mutex internally.
+ * Returns NULL if no record is found (not one of our mappings).
+ */
+static struct mmap_record *
+__mmap_record_take(void *user_ptr)
+{
+    struct mmap_record * volatile *pp;
+    struct mmap_record *rec;
+    struct _clib4 *__clib4 = __CLIB4;
+
+    __memory_lock(__clib4);
+    pp = &__mmap_records;
+    while (*pp && (*pp)->user_ptr != user_ptr)
+        pp = &(*pp)->next;
+    rec = *pp;
+    if (rec)
+        *pp = rec->next;
+    __memory_unlock(__clib4);
+
+    return rec;
+}
 
 int
 munmap(void *map, size_t length) {
@@ -22,24 +52,46 @@ munmap(void *map, size_t length) {
         return -1;
     }
 
-    struct mmap_header *hdr = __mmap_get_header(map);
-    if (hdr) {
-        /* Write back MAP_SHARED file-backed mappings before freeing */
-        __mmap_writeback(hdr, map, hdr->length);
-
-        /* Close our dup'd fd */
-        if (hdr->fd >= 0) {
-            close(hdr->fd);
-            hdr->fd = -1;
+    /*
+     * Look up the pointer in our authoritative tracking list first.
+     * This is safe even if the in-page header has been corrupted or
+     * is a false positive (file content matching MMAP_MAGIC).
+     */
+    struct mmap_record *rec = __mmap_record_take(map);
+    if (rec) {
+        /*
+         * Still try to use the in-page header for MAP_SHARED write-back
+         * (read-only access — no risk of acting on a corrupted alloc_base).
+         */
+        struct mmap_header *hdr = __mmap_get_header(map);
+        if (hdr != NULL) {
+            __mmap_writeback(hdr, map, hdr->length);
+            hdr->magic = 0; /* Invalidate to catch double-munmap early */
         }
 
-        hdr->magic = 0; /* Invalidate */
-        free(hdr->alloc_base); /* Free the whole memalign'd block */
-    } else {
-        /* Legacy path: no tracking header, just free as before */
-        free(map);
+        /* Close the dup()'d file descriptor stored in the record */
+        if (rec->fd >= 0)
+            close(rec->fd);
+
+        /* Free the backing allocation — always via FreeVec() since mmap()
+         * now allocates all backing blocks (both MEMF_SHARED and
+         * MEMF_EXECUTABLE) with AllocVecTags() directly. */
+        FreeVec(rec->alloc_base);
+
+        /* Release the tracking record itself */
+        FreeVec(rec);
+
+        RETURN(0);
+        return 0;
     }
 
+    /*
+     * Not in our tracking list — not a mapping we allocated.
+     * Do NOT call free(map): the pointer is not from our allocator and
+     * calling free() on it would corrupt the heap.
+     * Return success silently (the pointer was already unmapped or was
+     * never from mmap()).
+     */
     RETURN(0);
     return 0;
 }

--- a/library/shared_library/clib4.c
+++ b/library/shared_library/clib4.c
@@ -529,7 +529,16 @@ struct Clib4Library *libOpen(struct LibraryManagerInterface *Self, uint32 versio
 
             /* Set the current task pointer */
             __clib4->self = me;
-            __clib4->uuid = c2n.uuid;
+            /* Allocate a persistent copy of the uuid.
+             * Cannot point into the hashmap because resize invalidates pointers. */
+            __clib4->uuid = (char *) IExec->AllocVecTags(UUID4_LEN + 1,
+                                                         AVT_Type, MEMF_SHARED,
+                                                         AVT_ClearWithValue, 0,
+                                                         TAG_DONE);
+            if (__clib4->uuid) {
+                strncpy(__clib4->uuid, c2n.uuid, UUID4_LEN);
+                __clib4->uuid[UUID4_LEN] = '\0';
+            }
 
 			/* Get Actual Machine Type */
 			IExpansion->GetMachineInfoTags(GMIT_Machine, &__clib4->__machine_type, TAG_DONE);
@@ -789,6 +798,10 @@ BPTR libClose(struct LibraryManagerInterface *Self) {
          * still TRUE in freed memory and skip creating a new context.
          */
         me->pr_UID = 0;
+        if (__clib4->uuid) {
+            IExec->FreeVec(__clib4->uuid);
+            __clib4->uuid = NULL;
+        }
         IExec->FreeVec(__clib4);
     }
 
@@ -922,7 +935,7 @@ struct Clib4Library *libInit(struct Clib4Library *libBase, BPTR seglist, struct 
         goto out;
     }
 
-    struct Library *__ElfBase = IExec->OpenLibrary("elf.library", MIN_OS_VERSION);
+    __ElfBase = IExec->OpenLibrary("elf.library", MIN_OS_VERSION);
     if (__ElfBase) {
         if (__ElfBase->lib_Version == 52 && __ElfBase->lib_Revision == 1) { // .so stuff doesn't work with pre-52.2
             goto out;

--- a/library/shared_library/clib4.c
+++ b/library/shared_library/clib4.c
@@ -125,6 +125,11 @@ struct TimerIFace *ITimer = 0;
 struct Library *__UtilityBase = 0;
 struct UtilityIFace *__IUtility = 0;
 
+/* Cached MMU interface — avoids the heavy GetInterface/DropInterface
+ * overhead on every mprotect() call.  Obtained once at libInit and
+ * released at closeLibraries(). */
+struct MMUIFace *__IMMU = 0;
+
 struct Clib4IFace *IClib4 = 0;
 struct Clib4Library *Clib4Base = 0;
 
@@ -367,6 +372,11 @@ static void closeLibraries() {
     if (IDOS != NULL) {
         IExec->DropInterface((struct Interface *) IDOS);
         IDOS = NULL;
+    }
+
+    if (__IMMU != NULL) {
+        IExec->DropInterface((struct Interface *) __IMMU);
+        __IMMU = NULL;
     }
 }
 
@@ -935,6 +945,12 @@ struct Clib4Library *libInit(struct Clib4Library *libBase, BPTR seglist, struct 
     } else {
         goto out;
     }
+
+    /* Cache the MMU interface once so mprotect() never needs to call
+     * GetInterface/DropInterface at runtime.  It's OK if this returns NULL
+     * on hardware without an MMU — mprotect() handles that gracefully. */
+    __IMMU = (struct MMUIFace *)
+        IExec->GetInterface((struct Library *)IExec->Data.LibBase, "mmu", 1, NULL);
 
     /* Open resource */
     struct Clib4Resource *res = (APTR) iexec->OpenResource(RESOURCE_NAME);

--- a/library/socket/hook_entry.c
+++ b/library/socket/hook_entry.c
@@ -14,6 +14,7 @@ int64_t
 __socket_hook_entry(struct _clib4 *__clib4, struct fd *fd, struct file_action_message *fam) {
     struct ExamineData *fib;
     BOOL is_aliased;
+    BOOL is_stdio = FALSE;
     int result;
     int param;
 
@@ -66,7 +67,7 @@ __socket_hook_entry(struct _clib4 *__clib4, struct fd *fd, struct file_action_me
             is_aliased = __fd_is_aliased(fd);
             if (is_aliased) {
                 __remove_fd_alias(__clib4, fd);
-            } else {
+            } else if (FLAG_IS_CLEAR(fd->fd_Flags, FDF_STDIO)) {
                 /* Are we permitted to close this file? */
                 if (FLAG_IS_CLEAR(fd->fd_Flags, FDF_NO_CLOSE)) {
                     /* Check for unix socket */
@@ -85,16 +86,19 @@ __socket_hook_entry(struct _clib4 *__clib4, struct fd *fd, struct file_action_me
                     }
                     result = __CloseSocket(fd->fd_Socket);
                 }
+            } else {
+                /* FDF_STDIO is set — this is a STDIO fd. */
+                is_stdio = TRUE;
             }
             __fd_unlock(fd);
 
-            /* Free the locked mutex now. */
-            if (NOT is_aliased)
+            if (NOT is_aliased && !is_stdio)
                 __delete_mutex(fd->fd_Lock);
 
-            /* And that's the last for this file descriptor. */
-            memset(fd, 0, sizeof(*fd));
-            fd = NULL;
+            if (!is_stdio) {
+                memset(fd, 0, sizeof(*fd));
+                fd = NULL;
+            }
             break;
         case file_action_seek:
             SHOWMSG("file_action_seek");

--- a/library/stdio/popen.c
+++ b/library/stdio/popen.c
@@ -243,7 +243,8 @@ popen(const char *command, const char *type) {
     int asynch = TRUE; //FALSE
 
     /* Now try to launch the program. */
-	struct spawnData data = { getgid(), FindTask(NULL) };
+	struct spawnData data = { getgid(), FindTask(NULL), "" };
+	if (__CLIB4->uuid) strncpy(data.parentUuid, __CLIB4->uuid, UUID4_LEN);
     status = SystemTags((STRPTR) command,
                         SYS_Input,          input,
                         SYS_Output,         output,

--- a/library/stdio/stdio_rw.c
+++ b/library/stdio/stdio_rw.c
@@ -236,8 +236,11 @@ __sclose(void *cookie) {
         return -1;
     }
 
-    if (__builtin_expect(fd->fd_Original != NULL, 0))
-        fd = fd->fd_Original;
+    /* Do NOT resolve fd_Original here. For close, we must affect THIS
+     * specific fd slot — not the original in an alias chain. Following
+     * fd_Original would close the WRONG fd and corrupt the fd table.
+     * (Consistent with __iob_hook_entry which uses
+     *  __get_file_descriptor_dont_resolve for close operations.) */
 
     fam.fam_Action = file_action_close;
 

--- a/library/stdlib/qsort.c
+++ b/library/stdlib/qsort.c
@@ -61,6 +61,7 @@ void
 qsort(void *a, size_t n, size_t es, int (*cmp)(const void *, const void *)) {
     char *pa, *pb, *pc, *pd, *pl, *pm, *pn;
     size_t d, r, swaptype, swap_cnt;
+    int cr;
 
 loop:
     SWAPINIT(a, es);
@@ -89,16 +90,16 @@ loop:
 
     pc = pd = (char *) a + (n - 1) * es;
     for (;;) {
-        while (pb <= pc && (r = cmp(pb, a)) <= 0) {
-            if (r == 0) {
+        while (pb <= pc && (cr = cmp(pb, a)) <= 0) {
+            if (cr == 0) {
                 swap_cnt = 1;
                 swap(pa, pb);
                 pa += es;
             }
             pb += es;
         }
-        while (pb <= pc && (r = cmp(pc, a)) >= 0) {
-            if (r == 0) {
+        while (pb <= pc && (cr = cmp(pc, a)) >= 0) {
+            if (cr == 0) {
                 swap_cnt = 1;
                 swap(pc, pd);
                 pd -= es;

--- a/library/stdlib/stdlib_protos.h
+++ b/library/stdlib/stdlib_protos.h
@@ -102,6 +102,7 @@ extern int *__h_errno_r(struct _clib4 *__clib4);
 
 extern struct DOSIFace *IDOS;
 extern struct ExecIFace *IExec;
+extern struct MMUIFace  *__IMMU; /* cached MMU interface from libInit */
 
 /* Faster __check_abort version used when __clib4 is available in the caller function */
 inline void

--- a/library/termios/console_fdhookentry.c
+++ b/library/termios/console_fdhookentry.c
@@ -147,6 +147,7 @@ __termios_console_hook(struct _clib4 *__clib4, struct fd *fd, struct file_action
     int64_t result = EOF;
     int actual_out;
     BOOL is_aliased;
+    BOOL is_stdio = FALSE;
     BPTR file;
     struct termios *tios;
 
@@ -406,13 +407,15 @@ __termios_console_hook(struct _clib4 *__clib4, struct fd *fd, struct file_action
 
                     fd->fd_File = BZERO;
                 }
+            } else {
+                /* FDF_STDIO is set — this is a STDIO fd. */
+                is_stdio = TRUE;
             }
 
             __fd_unlock(fd);
 
-            /* Free the locked mutex now. */
-            if (NOT is_aliased) {
-                /* Free the termios structure if it was allocated */
+            /* Free resources — but not for STDIO or aliased fds. */
+            if (NOT is_aliased && !is_stdio) {
                 if (fd->fd_Aux != NULL && FLAG_IS_SET(fd->fd_Flags, FDF_TERMIOS)) {
                     free(fd->fd_Aux);
                     fd->fd_Aux = NULL;
@@ -421,9 +424,10 @@ __termios_console_hook(struct _clib4 *__clib4, struct fd *fd, struct file_action
                 __delete_mutex(fd->fd_Lock);
             }
 
-            /* And that's the last for this file descriptor. */
-            memset(fd, 0, sizeof(*fd));
-            fd = NULL;
+            if (!is_stdio) {
+                memset(fd, 0, sizeof(*fd));
+                fd = NULL;
+            }
 
             break;
 

--- a/library/unistd/access.c
+++ b/library/unistd/access.c
@@ -145,7 +145,8 @@ access(const char *path_name, int mode) {
 out:
 
     FreeDosObject(DOS_EXAMINEDATA, status);
-    UnLock(lock);
+    if (lock != BZERO)
+        UnLock(lock);
 
     RETURN(result);
     return (result);

--- a/library/unistd/chdir.c
+++ b/library/unistd/chdir.c
@@ -85,7 +85,7 @@ chdir(const char *path_name) {
 
         old_dir = SetCurrentDir(dir_lock);
 
-        if (__clib4->__unlock_current_directory)
+        if (__clib4->__unlock_current_directory && old_dir != BZERO)
             UnLock(old_dir);
     } else {
         __clib4->__original_current_directory = SetCurrentDir(dir_lock);
@@ -108,7 +108,8 @@ chdir(const char *path_name) {
 out:
 
     FreeDosObject(DOS_EXAMINEDATA, status);
-    UnLock(dir_lock);
+    if (dir_lock != BZERO)
+        UnLock(dir_lock);
 
     RETURN(result);
     return (result);

--- a/library/unistd/chdir_exit.c
+++ b/library/unistd/chdir_exit.c
@@ -20,7 +20,7 @@ CLIB_DESTRUCTOR(__chdir_exit) {
         old_dir = SetCurrentDir(__clib4->__original_current_directory);
         __clib4->__original_current_directory = BZERO;
 
-        if (__clib4->__unlock_current_directory) {
+        if (__clib4->__unlock_current_directory && old_dir != BZERO) {
             UnLock(old_dir);
 
             __clib4->__unlock_current_directory = FALSE;

--- a/library/unistd/fchown.c
+++ b/library/unistd/fchown.c
@@ -104,7 +104,8 @@ out:
     if (isFdLocked)
         __fd_unlock(fd);
 
-    UnLock(parent_dir);
+    if (parent_dir != BZERO)
+        UnLock(parent_dir);
 
     if (current_dir_changed)
         SetCurrentDir(old_current_dir);

--- a/library/unistd/init_exit.c
+++ b/library/unistd/init_exit.c
@@ -40,7 +40,8 @@ CLIB_DESTRUCTOR(unistd_exit) {
             Delete(uln->uln_Name);
             SetCurrentDir(old_dir);
 
-            UnLock(uln->uln_Lock);
+            if (uln->uln_Lock != BZERO)
+                UnLock(uln->uln_Lock);
         }
     }
 

--- a/library/unistd/link.c
+++ b/library/unistd/link.c
@@ -75,7 +75,8 @@ link(const char *existing_path, const char *new_path) {
 
 out:
 
-    UnLock(existing_path_lock);
+    if (existing_path_lock != BZERO)
+        UnLock(existing_path_lock);
 
     RETURN(result);
     return (result);

--- a/library/unistd/readlink.c
+++ b/library/unistd/readlink.c
@@ -76,7 +76,8 @@ readlink(const char *path_name, char *buffer, int buffer_size) {
 
 out:
 
-    UnLock(lock);
+    if (lock != BZERO)
+        UnLock(lock);
 
     RETURN(result);
     return (result);

--- a/library/unistd/spawnv.c
+++ b/library/unistd/spawnv.c
@@ -73,7 +73,8 @@ spawnv(int mode, const char *file, const char **argv) {
     BPTR out = DupFileHandle(Output());
     BPTR err = DupFileHandle(ErrorOutput());
     D(("Launching [%s]", command));
-	struct spawnData data = { getgid(), FindTask(NULL) };
+	struct spawnData data = { getgid(), FindTask(NULL), "" };
+	if (__CLIB4->uuid) strncpy(data.parentUuid, __CLIB4->uuid, UUID4_LEN);
     ret = SystemTags(command,
                      SYS_Input, in,
                      SYS_Output, out,

--- a/library/unistd/spawnvpe.c
+++ b/library/unistd/spawnvpe.c
@@ -214,7 +214,8 @@ spawnvpe(
 
     D(("(*)Calling SystemTags.\n"));
 
-	struct spawnData data = { getgid(), FindTask(NULL) };
+	struct spawnData data = { getgid(), FindTask(NULL), "" };
+	if (__CLIB4->uuid) strncpy(data.parentUuid, __CLIB4->uuid, UUID4_LEN);
     ret = SystemTags(full_command,
                     NP_NotifyOnDeathSigTask, me,
                     SYS_Input,          iofh[0],

--- a/library/unistd/spawnvpe_fork.c
+++ b/library/unistd/spawnvpe_fork.c
@@ -320,7 +320,8 @@ spawnvpe_fork(
     }
 
     D(("Closed %d file descriptors with FD_CLOEXEC before exec\n", num_closed));
-	struct spawnData data = { getgid(), thisTask };
+	struct spawnData data = { getgid(), thisTask, "" };
+	if (__CLIB4->uuid) strncpy(data.parentUuid, __CLIB4->uuid, UUID4_LEN);
     struct TagItem tags[] = {
         { NP_Seglist,           (ULONG) seglist },     /* FIX: Use NP_Seglist not NP_Entry! */
         { NP_Name,              (ULONG) process_name },
@@ -379,7 +380,7 @@ spawnvpe_fork(
     ret = child_proc->pr_ProcessID;
 
     /* Register child process in our tracking system */
-    if (insertSpawnedChildren(ret, GetPID(0, GPID_PROCESS), getgid())) {
+    if (insertSpawnedChildren(ret, getgid(), __clib4->uuid ? __clib4->uuid : "")) {
         __clib4->__children++;
         D(("Child process registered: PID=%ld\n", ret));
     } else {

--- a/library/unistd/unlink.c
+++ b/library/unistd/unlink.c
@@ -121,7 +121,8 @@ unlink(const char *path_name) {
 
 out:
 
-    UnLock(current_dir);
+    if (current_dir != BZERO)
+        UnLock(current_dir);
 
     RETURN(result);
     return (result);

--- a/library/wait/waitpid.c
+++ b/library/wait/waitpid.c
@@ -11,7 +11,7 @@
 #include "clib4.h"
 
 pid_t waitpid(pid_t pid, int *status, int options) {
-    // Delay(1);
+    struct _clib4 *__clib4 = __CLIB4;
     uint32 me = GetPID(0, GPID_PROCESS);
 
     if (options != 0 && options != WNOHANG) {
@@ -21,25 +21,27 @@ pid_t waitpid(pid_t pid, int *status, int options) {
 
     struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
     if (!res) {
-        *status = 0;
+        if (status) *status = 0;
         __set_errno(EINVAL);
         return -1;
     }
 
-    size_t childrenIter = 0;
-    void *childItem;
+    /* Use direct hashmap_get with uuid key instead of iterating.
+     * hashmap_iter can miss entries when the hashmap is concurrently modified
+     * by libOpen/libClose in other processes. */
+    struct Clib4Node nodeKey;
+    memset(&nodeKey, 0, sizeof(nodeKey));
+    strncpy(nodeKey.uuid, __clib4->uuid, UUID4_LEN);
+    const struct Clib4Node *node = hashmap_get(res->children, &nodeKey);
+
     uint32 pidFound = 0;
     BOOL done = FALSE;
 
-    while (!done && hashmap_iter(res->children, &childrenIter, &childItem)) {
-        const struct Clib4Node *node = childItem;
-        struct Clib4Children *children;
-
-        if (node->pid != me) continue;
+    if (node != NULL) {
 
         /* If we have no spawned processes return ECHILD error */
         if (node->spawnedProcesses == NULL || hashmap_count(node->spawnedProcesses) == 0) {
-            *status = 0;
+            if (status) *status = 0;
             __set_errno(ECHILD);
             return -1;
         }
@@ -56,8 +58,17 @@ pid_t waitpid(pid_t pid, int *status, int options) {
             struct Clib4Children *item = hashmap_get(node->spawnedProcesses, &key);
 
             if (item == NULL) {
+                /* In blocking mode, the child's NP_EntryCode may not have run yet.
+                 * Give it a moment to register, then retry once. */
+                if (!(options & WNOHANG)) {
+                    Delay(1);
+                    item = hashmap_get(node->spawnedProcesses, &key);
+                }
+            }
+
+            if (item == NULL) {
                 __set_errno(ECHILD);
-                *status = 0;
+                if (status) *status = 0;
                 D(("Child with pid %ld not found in spawned process list.\n", pid));
                 return -1;
             }
@@ -67,29 +78,38 @@ pid_t waitpid(pid_t pid, int *status, int options) {
                 found = CheckForChildExit(pid);
 
                 /* Set returnCode status */
-                *status = item->returnCode;
+                if (status) *status = item->returnCode;
                 
                 /* If returnCode still has 0x10000000 bit set, the child hasn't finished 
                  * its exit callback yet, so treat it as still running */
-                if (*status & 0x10000000) {
+                if (status && (*status & 0x10000000)) {
                     D(("Child with pid %ld exit callback not finished yet (status=0x%lx), treating as still running\n", pid, *status));
                     found = TRUE;  /* Treat as still running */
-                    *status = 0;
+                    if (status) *status = 0;
                 }
 
                 if (!found) hashmap_delete(node->spawnedProcesses, item);
 
-                D(("Child with pid %ld %s with status 0x%lx\n", pid, found ? "was found" : "has exited", *status));
+                D(("Child with pid %ld %s with status 0x%lx\n", pid, found ? "was found" : "has exited", status ? *status : 0));
             } else {
                 D(("Waiting for child with pid %ld to exit...", pid));
                 found = WaitForChildExit(pid);
 
+                /* WaitForChildExit may return before NP_ExitCode (spawnedProcessExit)
+                 * has cleared the 0x10000000 flag in returnCode. Wait briefly. */
+                if (item->returnCode & 0x10000000) {
+                    int retries = 50; /* up to ~1 second */
+                    while ((item->returnCode & 0x10000000) && retries-- > 0) {
+                        Delay(1);
+                    }
+                }
+
                 /* Set returnCode status */
-                *status = item->returnCode;
+                if (status) *status = item->returnCode;
 
                 hashmap_delete(node->spawnedProcesses, item);
 
-                D(("Child with pid %ld has (to the best of our knowledge) exited with status 0x%lx\n", pid, *status));
+                D(("Child with pid %ld has (to the best of our knowledge) exited with status 0x%lx\n", pid, status ? *status : 0));
             }
             pidFound = pid; done = TRUE;
         } else if (pid == -1) {
@@ -105,7 +125,7 @@ pid_t waitpid(pid_t pid, int *status, int options) {
 
                 if (!found) {
                     /* Set returnCode on Status */
-                    *status = children->returnCode;
+                    if (status) *status = children->returnCode;
 
                     hashmap_delete(node->spawnedProcesses, item);
                     pidFound = pid;
@@ -132,7 +152,7 @@ pid_t waitpid(pid_t pid, int *status, int options) {
 
                     if (!found) {
                         /* Set returnCode on status */
-                        *status = children->returnCode;
+                        if (status) *status = children->returnCode;
 
                         hashmap_delete(node->spawnedProcesses, item);
                         pidFound = pid;
@@ -143,6 +163,11 @@ pid_t waitpid(pid_t pid, int *status, int options) {
                 }
             }
         }
+    } else {
+        /* Our own node was not found — should not happen */
+        if (status) *status = 0;
+        __set_errno(ECHILD);
+        return -1;
     }
     return pidFound;
 }

--- a/library/wmem/wmem_allocator_block.c
+++ b/library/wmem/wmem_allocator_block.c
@@ -773,6 +773,12 @@ wmem_block_new_block(wmem_block_allocator_t *allocator) {
     /* allocate the new block and add it to the block list */
     block = (wmem_block_hdr_t *) wmem_alloc(NULL, WMEM_BLOCK_SIZE);
 
+    /* wmem_alloc(NULL,...) calls AllocVecTags(MEMF_SHARED,...); if it returns
+     * NULL (OOM) we must not proceed — writing through a NULL pointer would
+     * silently corrupt low memory where address 0 may be mapped. */
+    if (!block)
+        return;
+
     wmem_block_add_to_block_list(allocator, block);
 
     /* initialize it */
@@ -877,6 +883,11 @@ wmem_block_alloc(void *private_data, const size_t size, int32_t alignment) {
         if (!allocator->master_head) {        
             /* Allocate a new block if necessary. */
             wmem_block_new_block(allocator);
+            /* wmem_block_new_block() may fail (OOM) and leave master_head
+             * still NULL.  Return NULL here so malloc() can propagate ENOMEM
+             * cleanly instead of crashing via wmem_block_split_free_chunk. */
+            if (!allocator->master_head)
+                return NULL;
         }
 
         chunk = allocator->master_head;

--- a/test_programs/misc/test_spawnvpe_fork.c
+++ b/test_programs/misc/test_spawnvpe_fork.c
@@ -62,7 +62,7 @@ void create_echo_child_program(const char *filename) {
 
     /* Compile it with clib4 */
     char cmd[1024];
-    snprintf(cmd, sizeof(cmd), "gcc -o %s %s -mcrt=clib4 ", fullpath_exe, fullpath);
+    snprintf(cmd, sizeof(cmd), "gcc -o %s %s ", fullpath_exe, fullpath);
     printf("  Compiling: %s\n", cmd);
     int result = system(cmd);
     if (result != 0) {
@@ -107,7 +107,7 @@ void create_filter_child_program(const char *filename) {
 
     /* Compile it with clib4 */
     char cmd[1024];
-    snprintf(cmd, sizeof(cmd), "gcc -o %s %s -mcrt=clib4 ", fullpath_exe, fullpath);
+    snprintf(cmd, sizeof(cmd), "gcc -o %s %s ", fullpath_exe, fullpath);
     printf("  Compiling: %s\n", cmd);
     int result = system(cmd);
     if (result != 0) {

--- a/test_programs/misc/test_spawnvpe_fork_simple.c
+++ b/test_programs/misc/test_spawnvpe_fork_simple.c
@@ -30,12 +30,12 @@ int main() {
     }
 
     /* Spawn echo command that writes to stdout (which is our pipe) */
-    const char *argv1[] = {"C:echo", "Hello from spawnvpe_fork!", NULL};
+    const char *argv1[] = {"echo", "Hello from spawnvpe_fork!", NULL};
 
-    printf("  Spawning: C:echo \"Hello from spawnvpe_fork!\"\n");
+    printf("  Spawning: echo \"Hello from spawnvpe_fork!\"\n");
     printf("  Redirecting stdout to pipe...\n");
 
-    pid_t pid1 = spawnvpe_fork("C:echo", argv1, NULL, NULL, -1, pipefd[1], -1);
+    pid_t pid1 = spawnvpe_fork("echo", argv1, NULL, NULL, -1, pipefd[1], -1);
 
     if (pid1 < 0) {
         TEST_FAIL("spawnvpe_fork failed");
@@ -87,8 +87,8 @@ int main() {
     }
 
     /* Spawn a quick command */
-    const char *argv2[] = {"C:echo", "quick", NULL};
-    pid_t pid2 = spawnvpe_fork("C:echo", argv2, NULL, NULL, -1, pipefd[1], -1);
+    const char *argv2[] = {"echo", "quick", NULL};
+    pid_t pid2 = spawnvpe_fork("echo", argv2, NULL, NULL, -1, pipefd[1], -1);
 
     if (pid2 < 0) {
         TEST_FAIL("spawnvpe_fork failed");
@@ -132,13 +132,13 @@ int main() {
     }
 
     /* Spawn multiple children */
-    const char *argv3a[] = {"C:echo", "Child1", NULL};
-    const char *argv3b[] = {"C:echo", "Child2", NULL};
-    const char *argv3c[] = {"C:echo", "Child3", NULL};
+    const char *argv3a[] = {"echo", "Child1", NULL};
+    const char *argv3b[] = {"echo", "Child2", NULL};
+    const char *argv3c[] = {"echo", "Child3", NULL};
 
-    pid_t pid3a = spawnvpe_fork("C:echo", argv3a, NULL, NULL, -1, pipefd[1], -1);
-    pid_t pid3b = spawnvpe_fork("C:echo", argv3b, NULL, NULL, -1, pipefd[1], -1);
-    pid_t pid3c = spawnvpe_fork("C:echo", argv3c, NULL, NULL, -1, pipefd[1], -1);
+    pid_t pid3a = spawnvpe_fork("echo", argv3a, NULL, NULL, -1, pipefd[1], -1);
+    pid_t pid3b = spawnvpe_fork("echo", argv3b, NULL, NULL, -1, pipefd[1], -1);
+    pid_t pid3c = spawnvpe_fork("echo", argv3c, NULL, NULL, -1, pipefd[1], -1);
 
     if (pid3a < 0 || pid3b < 0 || pid3c < 0) {
         TEST_FAIL("Could not spawn all children");

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,8 @@
+test_string
+test_stdlib
+test_stdio
+test_math
+test_time
+test_shm
+test_mmap
+test_mlock

--- a/tests/test_stdlib.c
+++ b/tests/test_stdlib.c
@@ -237,6 +237,96 @@ static const char *test_qsort(void) {
     return NULL;
 }
 
+/* Test qsort with large array (triggers quicksort path, n >= 7) */
+static const char *test_qsort_large(void) {
+    int arr[] = {42, 17, 93, 5, 81, 33, 62, 8, 55, 21, 77, 3, 99, 14, 48, 70};
+    int n = sizeof(arr) / sizeof(arr[0]);
+    int i;
+
+    qsort(arr, n, sizeof(int), compare_ints);
+
+    for (i = 1; i < n; i++) {
+        if (arr[i - 1] > arr[i]) {
+            printf("  FAIL: qsort_large: arr[%d]=%d > arr[%d]=%d\n", i-1, arr[i-1], i, arr[i]);
+            TEST_ASSERT("qsort large array not sorted", 0);
+        }
+    }
+    TEST_ASSERT("qsort large array sorted", 1);
+    return NULL;
+}
+
+/* Test qsort with reverse-sorted array */
+static const char *test_qsort_reverse(void) {
+    int arr[] = {100, 90, 80, 70, 60, 50, 40, 30, 20, 10};
+    int n = sizeof(arr) / sizeof(arr[0]);
+    int i;
+
+    qsort(arr, n, sizeof(int), compare_ints);
+
+    for (i = 1; i < n; i++) {
+        if (arr[i - 1] > arr[i]) {
+            printf("  FAIL: qsort_reverse: arr[%d]=%d > arr[%d]=%d\n", i-1, arr[i-1], i, arr[i]);
+            TEST_ASSERT("qsort reverse array not sorted", 0);
+        }
+    }
+    TEST_ASSERT_EQUAL("qsort reverse first", 10, arr[0]);
+    TEST_ASSERT_EQUAL("qsort reverse last", 100, arr[n-1]);
+    return NULL;
+}
+
+/* Test qsort with duplicates */
+static const char *test_qsort_duplicates(void) {
+    int arr[] = {5, 3, 5, 1, 3, 5, 2, 1, 4, 3, 2, 5};
+    int n = sizeof(arr) / sizeof(arr[0]);
+    int i;
+
+    qsort(arr, n, sizeof(int), compare_ints);
+
+    for (i = 1; i < n; i++) {
+        if (arr[i - 1] > arr[i]) {
+            printf("  FAIL: qsort_duplicates: arr[%d]=%d > arr[%d]=%d\n", i-1, arr[i-1], i, arr[i]);
+            TEST_ASSERT("qsort duplicates not sorted", 0);
+        }
+    }
+    return NULL;
+}
+
+/* Test qsort simulating git's ofs_delta sorting (large offsets) */
+static int compare_offsets(const void *a, const void *b) {
+    unsigned long va = *(const unsigned long *)a;
+    unsigned long vb = *(const unsigned long *)b;
+    /* Same pattern git uses: avoid subtraction overflow */
+    if (va < vb) return -1;
+    if (va > vb) return 1;
+    return 0;
+}
+
+static const char *test_qsort_git_offsets(void) {
+    /* Values from the actual failing git clone log */
+    unsigned long offsets[] = {
+        271375727, 170065653, 212509025, 271299218,
+        209182867, 178068276, 201899763, 26487398,
+        26496863, 26501811, 26489280, 26503081,
+        26508037, 271074828, 26507275, 26489280,
+        26498766, 26489722, 26499188, 26508926,
+        26511804, 26507639, 170066584, 53036
+    };
+    int n = sizeof(offsets) / sizeof(offsets[0]);
+    int i;
+
+    qsort(offsets, n, sizeof(unsigned long), compare_offsets);
+
+    for (i = 1; i < n; i++) {
+        if (offsets[i - 1] > offsets[i]) {
+            printf("  FAIL: qsort_git_offsets: offsets[%d]=%lu > offsets[%d]=%lu\n",
+                   i-1, offsets[i-1], i, offsets[i]);
+            TEST_ASSERT("qsort git offsets not sorted", 0);
+        }
+    }
+    TEST_ASSERT("qsort git offsets sorted", 1);
+    return NULL;
+}
+
 /* Test bsearch */
 static const char *test_bsearch(void) {
     int arr[] = {1, 2, 3, 5, 8, 9};
@@ -312,6 +402,10 @@ int main(void) {
     RUN_TEST(test_realloc);
     RUN_TEST(test_rand);
     RUN_TEST(test_qsort);
+    RUN_TEST(test_qsort_large);
+    RUN_TEST(test_qsort_reverse);
+    RUN_TEST(test_qsort_duplicates);
+    RUN_TEST(test_qsort_git_offsets);
     RUN_TEST(test_bsearch);
     RUN_TEST(test_getenv);
     RUN_TEST(test_system);


### PR DESCRIPTION
This PR cherry-picks only the stable subset of changes from 3f3380f4 and explicitly excludes the stdio refactor files that were causing exit-time crashes.
It keeps the runtime behavior stable on AmigaOS4 while preserving the targeted fixes in mprotect/FD hooks and related spawnvpe test updates.