### PR TITLE
Included development branch in PR action

### DIFF
--- a/.github/workflows/prChecks.yml
+++ b/.github/workflows/prChecks.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - development
     types: 
       - opened
       - reopened


### PR DESCRIPTION
I added the development branch in the PR action. This will run when a PR is opened or reopened and will compile the clib4 for both SPE and non-SPE CPUs. If that fails we will be able to recognise a problem at that level