### PR TITLE
Disable array-bound error on shared object creation

### DIFF
--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -366,7 +366,7 @@ endef
 define COMPILE_SHARED
 $(VERBOSE)@$(MAKEDIR) $(@D)
 $(VERBOSE)echo -e "\rCompiling Shared \033[0;33m[$(@D)]\033[0m \r\t\t\t\t\t\t\t\t\t\t\t \033[0;31m$(@F)\033[0m"
-$(VERBOSE)$(CC) $(CFLAGS) $(PIC) -DSHARED -o $@ -c $< $(LOG_COMMAND)
+$(VERBOSE)$(CC) $(CFLAGS) $(PIC) -DSHARED -Wno-array-bounds -o $@ -c $< $(LOG_COMMAND)
 endef
 
 define COMPILE_SHARED_ASM

--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -73,8 +73,8 @@ WARNINGS := \
 	-Wundef -Wmissing-declarations -Wunused -Wwrite-strings -Wno-unused-value -Wno-comment -Wno-missing-braces \
 	-Wno-deprecated-declarations -Wno-unused-variable -Wno-parentheses -Wno-missing-prototypes \
 	-Wstrict-aliasing -Wno-shadow -Wno-discarded-qualifiers -Wno-unused-function -Wno-unused-parameter -Wno-strict-aliasing \
-    -Wno-type-limits -Wno-cast-function-type -Wno-frame-address -Wno-error=unused-but-set-variable  -Werror
-     # -Wbad-function-cast -Wconversion -Wformat
+	-Wno-type-limits -Wno-cast-function-type -Wno-frame-address -Wno-error=unused-but-set-variable -Wno-array-bounds -Werror
+	# -Wbad-function-cast -Wconversion -Wformat
 
 ifndef SPE
 WARNINGS += -Wno-prio-ctor-dtor -Wno-stringop-overflow
@@ -366,7 +366,7 @@ endef
 define COMPILE_SHARED
 $(VERBOSE)@$(MAKEDIR) $(@D)
 $(VERBOSE)echo -e "\rCompiling Shared \033[0;33m[$(@D)]\033[0m \r\t\t\t\t\t\t\t\t\t\t\t \033[0;31m$(@F)\033[0m"
-$(VERBOSE)$(CC) $(CFLAGS) $(PIC) -DSHARED -Wno-array-bounds -o $@ -c $< $(LOG_COMMAND)
+$(VERBOSE)$(CC) $(CFLAGS) $(PIC) -DSHARED -o $@ -c $< $(LOG_COMMAND)
 endef
 
 define COMPILE_SHARED_ASM


### PR DESCRIPTION
> GCC flags this as array subscript 0 is outside array bounds because dereferencing address 4 (an AmigaOS-specific low-memory access pattern) triggers the bounds checker.

This PR fixes the following error:

```
/opt/adtools/native-build/downloads/clib4/library/shared_library/stubs_common.c: In function '__exit_clib4_so':
/opt/adtools/native-build/downloads/clib4/library/shared_library/stubs_common.c:37:36: error: array subscript 0 is outside array bounds of 'struct ExecBase *[0]' [-Werror=array-bounds=]
   37 |         struct ExecBase *sysbase = *(struct ExecBase **)4;
      |                                    ^~~~~~~~~~~~~~~~~~~~~~
cc1: note: source object is likely at address zero
In function '__init_clib4_so',
    inlined from '__init_clib4_so' at /opt/adtools/native-build/downloads/clib4/library/shared_library/stubs_common.c:23:13:
/opt/adtools/native-build/downloads/clib4/library/shared_library/stubs_common.c:26:22: error: array subscript 0 is outside array bounds of 'struct ExecBase *[0]' [-Werror=array-bounds=]
   26 |     struct ExecBase *sysbase = *(struct ExecBase **)4;
      |                      ^~~~~~~
In function '__init_clib4_so':
cc1: note: source object is likely at address zero
Compiling string_bcmp.c [obj/libc]
Compiling Shared [/opt/adtools/native-build/downloads/clib4/build/obj.shared/libc/shared stubs_conjl.o
cc1: all warnings being treated as errors
make[1]: *** [libc.gmk:1059: /opt/adtools/native-build/downloads/clib4/build/obj.shared/libc/shared_library/stubs_common.o] Error 1
```