### PR TITLE
Fixing when nightly version string is applied

### DIFF
--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -275,7 +275,7 @@ ifdef GITTAG
 	$(VERBOSE)sed -i 's/Version: [0-9]*\.[0-9]*/Version: $(MAJOR).$(MINOR)/g' misc/control
 endif
 
-ifdef NIGHTLY
+ifneq ($(filter YES yes,$(NIGHTLY)),)
 	$(VERBOSE)sed -i 's/clib4.library \([0-9]*\.[0-9]*\)-\([a-z0-9]*\)/clib4.library \1-nightly-$(GIT_HASH)/g' library/c.lib_rev.h
 endif
 


### PR DESCRIPTION
The nightly label in the version string was applied no matter if the value was `yes` or `no` . This PR fixes that.