### PR TITLE
Fix array bound errors when compiled with gcc13

### DIFF
--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -73,7 +73,7 @@ WARNINGS := \
 	-Wundef -Wmissing-declarations -Wunused -Wwrite-strings -Wno-unused-value -Wno-comment -Wno-missing-braces \
 	-Wno-deprecated-declarations -Wno-unused-variable -Wno-parentheses -Wno-missing-prototypes \
 	-Wstrict-aliasing -Wno-shadow -Wno-discarded-qualifiers -Wno-unused-function -Wno-unused-parameter -Wno-strict-aliasing \
-    -Wno-type-limits -Wno-cast-function-type -Wno-frame-address -Wno-error=unused-but-set-variable  -Werror
+    -Wno-type-limits -Wno-cast-function-type -Wno-frame-address -Wno-error=unused-but-set-variable -Werror
      # -Wbad-function-cast -Wconversion -Wformat
 
 ifndef SPE

--- a/library/profile/_mcount.c
+++ b/library/profile/_mcount.c
@@ -9,6 +9,8 @@
 
 #include "gmon.h"
 
+volatile uintptr_t exec_addr = 4;
+
 void __mcount(uint32 frompc, uint32 selfpc);
 
 void

--- a/library/profile/gmon.h
+++ b/library/profile/gmon.h
@@ -9,7 +9,8 @@
 #include "../shared_library/math.h"
 
 #undef DebugPrintF
-#define dprintf(format, args...) ((struct ExecIFace *)((*(struct ExecBase **)4)->MainInterface))->DebugPrintF("[%s] " format, __PRETTY_FUNCTION__, ##args)
+extern volatile uintptr_t exec_addr;
+#define dprintf(format, args...) ((struct ExecIFace *)((*(struct ExecBase **)(exec_addr))->MainInterface))->DebugPrintF("[%s] " format, __PRETTY_FUNCTION__, ##args)
 
 void moncontrol(int);
 void monstartup(uint32, uint32);

--- a/library/shared_library/stubs_common.c
+++ b/library/shared_library/stubs_common.c
@@ -23,7 +23,8 @@ static struct Library *__clib4_so_base = NULL;
 static void __init_clib4_so(void) {
     if (IClib4 != NULL)
         return;
-    struct ExecBase *sysbase = *(struct ExecBase **)4;
+    volatile uintptr_t exec_addr = 4;
+    struct ExecBase *sysbase = *(struct ExecBase **)(exec_addr);
     struct ExecIFace *iexec = (struct ExecIFace *)sysbase->MainInterface;
     __clib4_so_base = iexec->OpenLibrary("clib4.library", 1);
     if (__clib4_so_base) {
@@ -34,7 +35,8 @@ static void __init_clib4_so(void) {
 
 static void __exit_clib4_so(void) {
     if (__clib4_so_base) {
-        struct ExecBase *sysbase = *(struct ExecBase **)4;
+        volatile uintptr_t exec_addr = 4;
+        struct ExecBase *sysbase = *(struct ExecBase **)(exec_addr);
         struct ExecIFace *iexec = (struct ExecIFace *)sysbase->MainInterface;
         IClib4 = NULL;
         iexec->CloseLibrary(__clib4_so_base);


### PR DESCRIPTION
This PR fixes the same error as the #417 but doesn't require disabling the array-bounds errors.
This was created based on @josefwegner feedback in #417 