### PR TITLE
pthread: wake cond/sem waiters when cancelled

### DIFF
--- a/library/pthread/pthread.c
+++ b/library/pthread/pthread.c
@@ -252,6 +252,16 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
     task = FindTask(NULL);
     inf = GetCurrentThreadInfo();
 
+    /* Include the thread's dedicated cancel signal in the wait mask.
+     * pthread_cancel() signals that mask to wake the target, but without
+     * it here a thread parked in a condition wait (or in sem_wait, which
+     * is built on top of this function) never wakes and the cancellation
+     * is never acted upon.  The SIGBREAKF_CTRL_C checks below only cover
+     * the fallback case where the dedicated signal could not be
+     * allocated at thread creation time. */
+    if (inf != NULL && inf->cancel_signal_mask != 0)
+        sigs |= inf->cancel_signal_mask;
+
     if (abstime) {
         // Compute relative time BEFORE sending the timer request.
         // This way, if the deadline has already passed we can return
@@ -363,16 +373,18 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
         // did we timeout?
         if (sigs & (1 << inf->timerPort.mp_SigBit))
             return ETIMEDOUT;
-        else if (sigs & SIGBREAKF_CTRL_C) {
+        else if (sigs & (SIGBREAKF_CTRL_C | (inf != NULL ? inf->cancel_signal_mask : 0))) {
             pthread_testcancel();
             // Re-Enable CTRL-C in case a signal handler is installed
-            Signal(task, SIGBREAKF_CTRL_C);
+            if (sigs & SIGBREAKF_CTRL_C)
+                Signal(task, SIGBREAKF_CTRL_C);
         }
     } else {
-        if (sigs & SIGBREAKF_CTRL_C) {
+        if (sigs & (SIGBREAKF_CTRL_C | (inf != NULL ? inf->cancel_signal_mask : 0))) {
             pthread_testcancel();
             // Re-Enable CTRL-C in case a signal handler is installed
-            Signal(task, SIGBREAKF_CTRL_C);
+            if (sigs & SIGBREAKF_CTRL_C)
+                Signal(task, SIGBREAKF_CTRL_C);
         }
     }
 


### PR DESCRIPTION
## Problem

`pthread_cancel()` of a thread blocked in `pthread_cond_wait` / `pthread_cond_timedwait` / `sem_wait` (which is built on the cond wait) is never acted upon: the target never wakes, and a subsequent `pthread_join` on it blocks forever.

The cause: `pthread_cancel()` signals the target's dedicated cancel signal (`inf->cancel_signal_mask`), but `_pthread_cond_timedwait()` does not include that signal in its `Wait()` mask — it only waits on the condvar waiter bit, the optional timer bit and `SIGBREAKF_CTRL_C`.

## Repro

```c
pthread_create(&t, NULL, fn_that_cond_waits_forever, NULL);
sleep(1);
pthread_cancel(t);      /* returns 0 */
pthread_join(t, &res);  /* hangs forever */
```

## Fix

Include the dedicated cancel signal in the wait mask and run `pthread_testcancel()` when woken by it — exactly as is already done for the `SIGBREAKF_CTRL_C` fallback. The existing cancellation cleanup handler (`CondWaitCleanupHandler`) already handles waiter-node removal and mutex reacquisition for this path, so cancellation semantics match POSIX (mutex is reacquired before cleanup handlers run).

## Validation

Tested on AmigaOS 4.1 FE (QEMU amigaone) with a clean `GNUmakefile.os4` build of this branch: cancel + join of a cond-parked thread and of a sem-parked thread both complete with `PTHREAD_CANCELED`. Found while porting OpenJDK 17 to AmigaOS 4, where JVM daemon threads parked in `pthread_cond_wait` could never be cancelled at VM shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)