### PR TITLE
pthread: cancel remaining live threads at process exit

### DIFF
--- a/library/pthread/pthread.c
+++ b/library/pthread/pthread.c
@@ -488,6 +488,20 @@ void __pthread_exit_func(void) {
     struct DOSIFace *IDOS = _IDOS;
     SHOWMSG("[__pthread_exit_func :] Pthread __pthread_exit_func called.\n");
 
+    /* A thread that never exits by itself (a daemon-style worker parked
+     * in pthread_cond_wait / sem_wait) would wedge the join/wait loop
+     * below forever, making the process unkillable.  On POSIX systems
+     * exit() simply terminates the remaining threads.  Approximate that:
+     * request cancellation of every live thread first, so parked threads
+     * wake, run their cancellation cleanup handlers and leave through
+     * the normal pthread exit path -- which keeps dos.library's
+     * parent/child process accounting intact (no force-removal). */
+    for (i = PTHREAD_FIRST_THREAD_ID; i < PTHREAD_THREADS_MAX; i++) {
+        inf = &threads[i];
+        if (inf->status != THREAD_STATE_IDLE && inf->task != NULL)
+            pthread_cancel(i);
+    }
+
     // if we don't do this we can easily end up with unloaded code being executed
     for (i = PTHREAD_FIRST_THREAD_ID; i < PTHREAD_THREADS_MAX; i++) {
         inf = &threads[i];

--- a/library/pthread/pthread.c
+++ b/library/pthread/pthread.c
@@ -252,6 +252,16 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
     task = FindTask(NULL);
     inf = GetCurrentThreadInfo();
 
+    /* Include the thread's dedicated cancel signal in the wait mask.
+     * pthread_cancel() signals that mask to wake the target, but without
+     * it here a thread parked in a condition wait (or in sem_wait, which
+     * is built on top of this function) never wakes and the cancellation
+     * is never acted upon.  The SIGBREAKF_CTRL_C checks below only cover
+     * the fallback case where the dedicated signal could not be
+     * allocated at thread creation time. */
+    if (inf != NULL && inf->cancel_signal_mask != 0)
+        sigs |= inf->cancel_signal_mask;
+
     if (abstime) {
         // Compute relative time BEFORE sending the timer request.
         // This way, if the deadline has already passed we can return
@@ -363,16 +373,18 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
         // did we timeout?
         if (sigs & (1 << inf->timerPort.mp_SigBit))
             return ETIMEDOUT;
-        else if (sigs & SIGBREAKF_CTRL_C) {
+        else if (sigs & (SIGBREAKF_CTRL_C | (inf != NULL ? inf->cancel_signal_mask : 0))) {
             pthread_testcancel();
             // Re-Enable CTRL-C in case a signal handler is installed
-            Signal(task, SIGBREAKF_CTRL_C);
+            if (sigs & SIGBREAKF_CTRL_C)
+                Signal(task, SIGBREAKF_CTRL_C);
         }
     } else {
-        if (sigs & SIGBREAKF_CTRL_C) {
+        if (sigs & (SIGBREAKF_CTRL_C | (inf != NULL ? inf->cancel_signal_mask : 0))) {
             pthread_testcancel();
             // Re-Enable CTRL-C in case a signal handler is installed
-            Signal(task, SIGBREAKF_CTRL_C);
+            if (sigs & SIGBREAKF_CTRL_C)
+                Signal(task, SIGBREAKF_CTRL_C);
         }
     }
 


### PR DESCRIPTION
## Problem

`__pthread_exit_func()` joins every non-idle joinable thread and spin-waits for detached ones at process exit. If the program exits while a daemon-style thread is parked forever in `pthread_cond_wait` / `sem_wait`, that loop never completes and the process becomes unkillable — `exit()` hangs in `pthread_join`.

On POSIX systems `exit()` terminates all remaining threads; on clib4 a single parked thread currently makes the process hang at exit.

## Fix

Request cancellation of every live thread before the existing join/wait loop. Parked threads wake (requires #428, on which this PR is stacked — the first commit here is that fix), run their cancellation cleanup handlers, and exit through the normal pthread path, so dos.library's parent/child process accounting stays intact — no force-removal of tasks. The join loop then completes as before.

Threads that exit promptly on their own are unaffected: cancellation is deferred and only acts at cancellation points.

## Validation

Tested on AmigaOS 4.1 FE (QEMU amigaone) with a clean `GNUmakefile.os4` build: a program that `return 0`'s from main with a thread still parked in `pthread_cond_wait` now terminates cleanly with no leftover tasks; previously it hung forever.

Real-world case: porting OpenJDK 17 to AmigaOS 4 — `java --version` printed its output, then the process hung forever in `__pthread_exit_func` joining the parked JVM daemon threads. With this change (plus #428) the JVM exits cleanly, repeatedly, with zero orphan tasks.

Note: this PR is stacked on #428 and will show its commit until that one merges; happy to rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)