### PR TITLE
pthread: pthread_getattr_np reports the real thread stack

### DIFF
--- a/library/pthread/pthread_getattr_np.c
+++ b/library/pthread/pthread_getattr_np.c
@@ -51,5 +51,18 @@ pthread_getattr_np(pthread_t thread, pthread_attr_t *attr) {
 
     *attr = inf->attr;
 
+    /* Report the thread's ACTUAL stack, matching the Linux/glibc
+     * semantics of pthread_getattr_np: callers chain this into
+     * pthread_attr_getstack() to derive the live stack bounds (stack
+     * overflow detection, GC stack scanning, ...).  The creation-time
+     * attr normally has stackaddr == NULL (and stacksize == 0 when the
+     * default was used), which sends such callers computing bounds far
+     * off the real stack.  The exec Task always knows the truth. */
+    if (inf->task != NULL) {
+        struct Task *t = (struct Task *) inf->task;
+        attr->stackaddr = t->tc_SPLower;
+        attr->stacksize = (size_t) ((char *) t->tc_SPUpper - (char *) t->tc_SPLower);
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Problem

`pthread_getattr_np()` returns a copy of the creation-time attributes, whose `stackaddr` is normally `NULL` (and `stacksize` 0 when the default size was used). The documented purpose of this Linux extension is the opposite: report the thread's **actual** stack, so callers can derive live stack bounds via `pthread_attr_getstack()` — language runtimes use this for stack-overflow detection and GC stack scanning.

With the current behaviour this standard idiom produces bounds unrelated to the real stack:

```c
pthread_getattr_np(pthread_self(), &attr);
pthread_attr_getstack(&attr, &addr, &size);
stack_top = (char *)addr + size;   /* garbage */
```

Found while porting OpenJDK 17 to AmigaOS 4: HotSpot sizes its Zero interpreter stack from these bounds and ended up attempting a ~1.6 GB `alloca`.

## Fix

Fill in the live values from the exec Task structure, which always knows the real stack: `tc_SPLower` / `tc_SPUpper`. Works for every thread including the main one (ThreadInfo slot 0).

## Validation

Tested on AmigaOS 4.1 FE (QEMU amigaone) with a clean `GNUmakefile.os4` build of this branch: bounds returned for the main thread and for pthread-created threads match the `tc_SPLower`/`tc_SPUpper` of the corresponding Task (verified against GrimReaper's per-task stack report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)