### PR TITLE
Fix/pthread create race condition

### DIFF
--- a/library/c.lib_rev.h
+++ b/library/c.lib_rev.h
@@ -1,7 +1,7 @@
 #define VERSION			2
 #define REVISION		1
 
-#define DATE			"07.06.2026"
+#define DATE			"19.06.2026"
 #define VERS			"clib4.library 2.1"
-#define VSTRING			"clib4.library 2.1 (07.06.2026)\r\n"
-#define VERSTAG			"\0$VER: clib4.library 2.1-nightly-c971606 (07.06.2026)"
+#define VSTRING			"clib4.library 2.1 (19.06.2026)\r\n"
+#define VERSTAG			"\0$VER: clib4.library 2.1-nightly-c971606 (19.06.2026)"

--- a/library/dos.h
+++ b/library/dos.h
@@ -309,8 +309,7 @@ struct _clib4 {
 
     APTR stdio_lock;
 
-    /* Wof Allocator main pointer */
-    wmem_allocator_t *__wmem_allocator;
+    void *unused1;
     APTR __environment_pool;
 
     /* Names of files and directories to delete when shutting down. */
@@ -319,7 +318,7 @@ struct _clib4 {
 
     /* Local timer I/O. */
     struct MsgPort *__timer_port;
-    BOOL unused1;
+    BOOL unused3;
 	void *unused2;
     struct TimeRequest *__timer_request;
     struct Library *__TimerBase;

--- a/library/pthread/pthread.c
+++ b/library/pthread/pthread.c
@@ -252,6 +252,16 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
     task = FindTask(NULL);
     inf = GetCurrentThreadInfo();
 
+    /* Include the thread's dedicated cancel signal in the wait mask.
+     * pthread_cancel() signals that mask to wake the target, but without
+     * it here a thread parked in a condition wait (or in sem_wait, which
+     * is built on top of this function) never wakes and the cancellation
+     * is never acted upon.  The SIGBREAKF_CTRL_C checks below only cover
+     * the fallback case where the dedicated signal could not be
+     * allocated at thread creation time. */
+    if (inf != NULL && inf->cancel_signal_mask != 0)
+        sigs |= inf->cancel_signal_mask;
+
     if (abstime) {
         // Compute relative time BEFORE sending the timer request.
         // This way, if the deadline has already passed we can return
@@ -363,16 +373,18 @@ _pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const stru
         // did we timeout?
         if (sigs & (1 << inf->timerPort.mp_SigBit))
             return ETIMEDOUT;
-        else if (sigs & SIGBREAKF_CTRL_C) {
+        else if (sigs & (SIGBREAKF_CTRL_C | (inf != NULL ? inf->cancel_signal_mask : 0))) {
             pthread_testcancel();
             // Re-Enable CTRL-C in case a signal handler is installed
-            Signal(task, SIGBREAKF_CTRL_C);
+            if (sigs & SIGBREAKF_CTRL_C)
+                Signal(task, SIGBREAKF_CTRL_C);
         }
     } else {
-        if (sigs & SIGBREAKF_CTRL_C) {
+        if (sigs & (SIGBREAKF_CTRL_C | (inf != NULL ? inf->cancel_signal_mask : 0))) {
             pthread_testcancel();
             // Re-Enable CTRL-C in case a signal handler is installed
-            Signal(task, SIGBREAKF_CTRL_C);
+            if (sigs & SIGBREAKF_CTRL_C)
+                Signal(task, SIGBREAKF_CTRL_C);
         }
     }
 
@@ -475,6 +487,20 @@ void __pthread_exit_func(void) {
     ThreadInfo *inf;
     struct DOSIFace *IDOS = _IDOS;
     SHOWMSG("[__pthread_exit_func :] Pthread __pthread_exit_func called.\n");
+
+    /* A thread that never exits by itself (a daemon-style worker parked
+     * in pthread_cond_wait / sem_wait) would wedge the join/wait loop
+     * below forever, making the process unkillable.  On POSIX systems
+     * exit() simply terminates the remaining threads.  Approximate that:
+     * request cancellation of every live thread first, so parked threads
+     * wake, run their cancellation cleanup handlers and leave through
+     * the normal pthread exit path -- which keeps dos.library's
+     * parent/child process accounting intact (no force-removal). */
+    for (i = PTHREAD_FIRST_THREAD_ID; i < PTHREAD_THREADS_MAX; i++) {
+        inf = &threads[i];
+        if (inf->status != THREAD_STATE_IDLE && inf->task != NULL)
+            pthread_cancel(i);
+    }
 
     // if we don't do this we can easily end up with unloaded code being executed
     for (i = PTHREAD_FIRST_THREAD_ID; i < PTHREAD_THREADS_MAX; i++) {

--- a/library/pthread/pthread_create.c
+++ b/library/pthread/pthread_create.c
@@ -348,7 +348,6 @@ pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)(voi
     _pthread_clear_threadinfo(inf);
     inf->status = THREAD_STATE_RUNNING; // Prevents another GetThreadId(NULL) from returning this slot
     inf->thread_id = threadnew;  /* Save our pthread_t ID */
-    MutexRelease(thread_sem);
 
     D(("pthread_create: slot %d reserved (task %p)\n", threadnew, inf->task));
     inf->start = start;
@@ -371,7 +370,9 @@ pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)(voi
     msgPort = AllocSysObject(ASOT_PORT, NULL);
     if (msgPort == 0) {
         SHOWMSG("Cannot allocate message port\n");
-        goto out;
+        _pthread_clear_threadinfo(inf); // Release the reserved slot back to IDLE
+        MutexRelease(thread_sem);
+        return EAGAIN;
     }
 
 	newThreadMessage = AllocSysObjectTags(ASOT_MESSAGE,
@@ -380,8 +381,14 @@ pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)(voi
 		TAG_DONE);
 	if (newThreadMessage == NULL) {
 		SHOWMSG("Cannot allocate message\n");
-		goto out;
-	}
+        
+        FreeSysObject(ASOT_PORT, msgPort);
+        msgPort = NULL;
+        
+        _pthread_clear_threadinfo(inf); // Release the reserved slot back to IDLE
+        MutexRelease(thread_sem);
+        return EAGAIN;
+    }
 
 
     /* Check minimum stack size */
@@ -434,6 +441,10 @@ out:
 			FreeSignal(inf->cancel_signal);
 			inf->cancel_signal = -1;
 		}
+        if (inf->join_signal != -1) {
+            FreeSignal(inf->join_signal);
+            inf->join_signal = -1;
+        }
     	if (newThreadMessage != NULL) {
     		FreeSysObject(ASOT_MESSAGE, newThreadMessage);
     		newThreadMessage = NULL;
@@ -443,6 +454,7 @@ out:
     		msgPort = NULL;
     	}
         _pthread_clear_threadinfo(inf); // Release the reserved slot back to IDLE
+        MutexRelease(thread_sem);
         return EAGAIN;
     }
 
@@ -455,6 +467,8 @@ out:
 	FreeSysObject(ASOT_PORT, msgPort);
 	newThreadMessage = NULL;
 	msgPort = NULL;
+
+    MutexRelease(thread_sem);
 
     return OK;
 }

--- a/library/shared_library/clib4.c
+++ b/library/shared_library/clib4.c
@@ -643,6 +643,13 @@ BPTR libExpunge(struct LibraryManagerInterface *Self) {
 
     struct Clib4Resource *res = (APTR) IExec->OpenResource(RESOURCE_NAME);
     if (res) {
+        IExec->ObtainSemaphore(&res->semaphore);
+        if (res->__wmem_allocator != NULL) {
+            wmem_destroy_allocator((wmem_allocator_t *) res->__wmem_allocator);
+            res->__wmem_allocator = NULL;
+        }
+        IExec->ReleaseSemaphore(&res->semaphore);
+
         IPCMapUninit(&res->shmcx.keymap);
         IPCMapUninit(&res->msgcx.keymap);
         IPCMapUninit(&res->semcx.keymap);
@@ -719,7 +726,7 @@ BPTR libClose(struct LibraryManagerInterface *Self) {
         }
 
         /* Always call clib4 internal destructors (__DTOR_LIST__).
-         * These include stdlib_memory_exit (frees wmem allocator),
+         * These include stdlib_memory_exit (frees per-process memory mutex),
          * stdio_exit, __pthread_exit, etc.
          * call_main() only handles __EXT_DTOR_LIST__ (the exe's own dtors),
          * not the library's internal __DTOR_LIST__. */

--- a/library/shared_library/clib4.h
+++ b/library/shared_library/clib4.h
@@ -30,6 +30,7 @@ struct Clib4Resource {
     struct SignalSemaphore  semaphore;          /* for list arbitration */
     struct hashmap         *children;           /* list of parent nodes */
     struct hashmap         *uxSocketsMap;
+    void                   *__wmem_allocator;   /* shared process-wide allocator singleton */
     struct _clib4          *fallbackClib;
     /* SysVIPC fields */
     int locked;

--- a/library/stdlib/free.c
+++ b/library/stdlib/free.c
@@ -16,15 +16,20 @@
 
 void
 __free_r(struct _clib4 *__clib4, void *ptr) {
+	wmem_allocator_t *allocator;
+
 	if (ptr == NULL || __clib4 == NULL)
 		return;
 
-	if (__clib4->__wmem_allocator == NULL) {
+	__memory_lock(__clib4);
+
+	allocator = __get_wmem_allocator(__clib4);
+	if (allocator == NULL) {
+		__memory_unlock(__clib4);
 		return;
 	}
 
-	__memory_lock(__clib4);
-    wmem_free(__clib4->__wmem_allocator, ptr);
+    wmem_free(allocator, ptr);
 
 	__memory_unlock(__clib4);
 }

--- a/library/stdlib/malloc.c
+++ b/library/stdlib/malloc.c
@@ -14,6 +14,19 @@
 #include "stdlib_constructor.h"
 #endif /* _STDLIB_CONSTRUCTOR_H */
 
+#include "../shared_library/clib4.h"
+
+wmem_allocator_t *
+__get_wmem_allocator(struct _clib4 *__clib4) {
+    (void) __clib4;
+
+    struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
+    if (res == NULL)
+        return NULL;
+
+    return (wmem_allocator_t *) res->__wmem_allocator;
+}
+
 void *
 malloc(size_t size) {
     return __malloc_r(__CLIB4, size);
@@ -27,6 +40,7 @@ __malloc_r(struct _clib4 *__clib4, size_t size) {
 void *
 __malloc_aligned_r(struct _clib4 *__clib4, size_t size, int32_t alignment) {
     void *result = NULL;
+    wmem_allocator_t *allocator;
 
     if(size == 0) size = 4;
 
@@ -38,7 +52,14 @@ __malloc_aligned_r(struct _clib4 *__clib4, size_t size, int32_t alignment) {
 
     __memory_lock(__clib4);
 
-    result = wmem_alloc_aligned(__clib4->__wmem_allocator, size, alignment);
+    allocator = __get_wmem_allocator(__clib4);
+    if (allocator == NULL) {
+        __set_errno_r(__clib4, ENOMEM);
+        __memory_unlock(__clib4);
+        goto out;
+    }
+
+    result = wmem_alloc_aligned(allocator, size, alignment);
 
     if (!result)
         __set_errno_r(__clib4, ENOMEM);
@@ -50,11 +71,21 @@ out:
 }
 
 void __memory_lock(struct _clib4 *__clib4) {
+    struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
+
     if(__clib4->memory_mutex)
         MutexObtain(__clib4->memory_mutex);
+
+    if (res != NULL)
+        ObtainSemaphore(&res->semaphore);
 }
 
 void __memory_unlock(struct _clib4 *__clib4) {
+    struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
+
+    if (res != NULL)
+        ReleaseSemaphore(&res->semaphore);
+
     if(__clib4->memory_mutex)
         MutexRelease(__clib4->memory_mutex);
 }
@@ -62,18 +93,6 @@ void __memory_unlock(struct _clib4 *__clib4) {
 STDLIB_DESTRUCTOR(stdlib_memory_exit) {
     ENTER();
     struct _clib4 *__clib4 = __CLIB4;
-
-    __memory_lock(__clib4);
-
-    if (__clib4->__wmem_allocator != NULL) {
-        SHOWMSG("Destroying Memory Allocator");
-        wmem_destroy_allocator(__clib4->__wmem_allocator);
-
-        SHOWMSG("Done");
-        __clib4->__wmem_allocator = NULL;
-    }
-
-    __memory_unlock(__clib4);
 
     if (__clib4->memory_mutex != NULL) {
         __delete_mutex(__clib4->memory_mutex);
@@ -87,6 +106,7 @@ STDLIB_DESTRUCTOR(stdlib_memory_exit) {
 STDLIB_CONSTRUCTOR(stdlib_memory_init) {
     BOOL success = FALSE;
     struct _clib4 *__clib4 = __CLIB4;
+    struct Clib4Resource *res;
 
     ENTER();
 
@@ -94,8 +114,20 @@ STDLIB_CONSTRUCTOR(stdlib_memory_init) {
     if (__clib4->memory_mutex == NULL)
         goto out;
 
-    __clib4->__wmem_allocator = wmem_allocator_new(__clib4->__wof_mem_allocator_type); // make this dynamic
-    if (__clib4->__wmem_allocator == NULL) {
+    res = (APTR) OpenResource(RESOURCE_NAME);
+    if (res == NULL) {
+        __delete_mutex(__clib4->memory_mutex);
+        __clib4->memory_mutex = NULL;
+        goto out;
+    }
+
+    ObtainSemaphore(&res->semaphore);
+    if (res->__wmem_allocator == NULL) {
+        res->__wmem_allocator = wmem_allocator_new(__clib4->__wof_mem_allocator_type);
+    }
+    ReleaseSemaphore(&res->semaphore);
+
+    if (res->__wmem_allocator == NULL) {
         __delete_mutex(__clib4->memory_mutex);
         __clib4->memory_mutex = NULL;
         goto out;

--- a/library/stdlib/realloc.c
+++ b/library/stdlib/realloc.c
@@ -16,14 +16,21 @@ void *
 realloc(void *ptr, size_t size) {
     void *result = NULL;
     struct _clib4 *__clib4 = __CLIB4;
+    wmem_allocator_t *allocator;
 
     assert((int) size >= 0);
 
     if (size == 0) size = 4;
-    
+
     __memory_lock(__clib4);
 
-    result = wmem_realloc(__clib4->__wmem_allocator, ptr, size);
+    allocator = __get_wmem_allocator(__clib4);
+    if (allocator == NULL) {
+        __memory_unlock(__clib4);
+        return NULL;
+    }
+
+    result = wmem_realloc(allocator, ptr, size);
     if (result == NULL) {
         SHOWMSG("could not reallocate memory");
     }

--- a/library/stdlib/stdlib_memory.h
+++ b/library/stdlib/stdlib_memory.h
@@ -44,6 +44,7 @@ typedef struct {
 
 extern void __memory_lock(struct _clib4 *__clib4);
 extern void __memory_unlock(struct _clib4 *__clib4);
+extern wmem_allocator_t *__get_wmem_allocator(struct _clib4 *__clib4);
 
 extern void __free_r(struct _clib4 *__clib4, void *ptr);
 

--- a/test_programs/threads/test_pthread_join_noprintf.c
+++ b/test_programs/threads/test_pthread_join_noprintf.c
@@ -129,6 +129,7 @@ int main(void) {
         for (int i = 0; i < NUM_PARENTS; i++) {
             pargs[i].parent_id = i;
             pargs[i].error_count = 0;
+            printf("MAIN: creating parent %d...\n", i);
             int rc = pthread_create(&pthr[i], NULL, parent_func, &pargs[i]);
             if (rc != 0) {
                 printf("MAIN: ERROR: pthread_create parent %d failed: %s\n",
@@ -137,6 +138,7 @@ int main(void) {
                 pargs[i].parent_id = -1;
                 failures++;
             }
+            printf("MAIN: parent %d created (thread=%p)\n", i, (void *)pthr[i]);
         }
 
         for (int i = 0; i < NUM_PARENTS; i++) {


### PR DESCRIPTION
When pthread_create was called in a loop with many threads a race condition could occur.
Now MutexRelease is called only before threads is complete