### PR TITLE
fix(altivec): vec_strcpy over-reads past the source page boundary (DSI crash on G4)

### DIFF
--- a/library/cpu/altivec/vec_strcpy.sx
+++ b/library/cpu/altivec/vec_strcpy.sx
@@ -145,7 +145,10 @@ vec_strcpy:
 	mr	DMS,SMD		// IU1 |dst - src| = src - dst
 Pos_value:
 	subf.	QBC,DST,ADD	// IU1 Bytes to even QW start of vect (min 32)
-	addi	ADD,DD,PAGE_SIZE	// IU1 dst addr in next 4K page
+	addi	ADD,SRC,PAGE_SIZE	// IU1 SRC addr in next 4K page (loads fault on
+					//     the SOURCE, so guard the source's page,
+					//     not the dest's -- else an unmapped page
+					//     just past src faults while dst is mid-page)
 	cmpi	cr7,0,DMS,MIN_VEC	// IU1 Check for min byte count separation
 
 	mtctr	QBC		// IU2 Init counter
@@ -171,7 +174,12 @@ v_strcpy:
 #ifdef VRSAVE
 	mfspr	RSV,VRSV	// IU2 Get current VRSAVE contents
 #endif
-	subf.	PBC,DD,ADD	// IU1 Now bytes to next 4K page
+	rlwinm	Rt,DS,0,0,27	// IU1 Align src down to QW first: lvx loads are
+				//     16-aligned (use DS&~15), so an unaligned
+				//     (rg-DS)/16 rounds to 0 and New_page_0 then
+				//     loads a whole page past the src page end
+	subf.	PBC,Rt,ADD	// IU1 QW-exact bytes from aligned src to its 4K
+				//     page boundary (loads fault on SRC, not dest)
 
 #ifdef VRSAVE
 	oris	Rt,RSV,0xff00	// IU1 Or in registers used by this routine

--- a/test_programs/memory/altivec_guard.c
+++ b/test_programs/memory/altivec_guard.c
@@ -1,0 +1,141 @@
+/*
+ * altivec_guard.c -- expose tail over-read / over-write in clib4's AltiVec
+ * string/mem routines (the ones actually selected on a G4).
+ *
+ * clib4.c (libOpen) routes, on an AltiVec CPU:
+ *     strcpy -> vec_strcpy   memcmp -> vec_memcmp
+ *     bzero  -> vec_bzero    bcopy  -> vec_bcopy
+ * (memcpy/memmove are NOT AltiVec-routed, which is why a memcpy-only test
+ *  passes -- see memcpy_guard.c.)  These hand-written routines
+ * (library/cpu/altivec/*.sx) use the classic "load two vectors + vperm"
+ * unaligned idiom, which can touch up to 15 bytes past the end of a buffer.
+ * Harmless mid-heap, but it FAULTS (DSI) when the buffer ends just before an
+ * unmapped page -- e.g. a class-name UTF-8 string compared during VM class
+ * loading, which crashed JamVM on the QEMU 'amigaone' (G4) target.
+ *
+ * This test puts the READ buffer (bcopy/memcmp/strcpy source) and the WRITE
+ * buffer (bzero dest) so they end EXACTLY at a PROT_NONE guard page, so any
+ * access one byte past the requested length faults.  A SIGSEGV handler +
+ * siglongjmp lets the sweep continue and name the offending routine+length.
+ * If clib4 does not deliver SIGSEGV, the process hard-crashes at the first
+ * offending case (Grim Reaper) -- itself the proof; the stderr breadcrumb
+ * (printed every 64 lengths) narrows it down.
+ *
+ * Only meaningful on AltiVec CPUs (G4 and the QEMU 'amigaone' machine).  On
+ * non-AltiVec CPUs (G3, 440/460, X5000/P5020, A1222/P1022) clib4 uses scalar
+ * routines and this should PASS.
+ *
+ * Build: drop in test_programs/memory/; `make compile-tests` builds it with
+ *        -mcrt=clib4 -fno-builtin.  PASS == rc 0.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>      /* bcopy, bzero */
+#include <stdint.h>
+#include <signal.h>
+#include <setjmp.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
+static sigjmp_buf g_jmp;
+static volatile sig_atomic_t g_faulted;
+
+static void on_segv(int sig) {
+    (void) sig;
+    g_faulted = 1;
+    siglongjmp(g_jmp, 1);
+}
+
+static unsigned char *map_guarded(long pg, unsigned char **guard) {
+    unsigned char *base = mmap(NULL, 2 * pg, PROT_READ | PROT_WRITE,
+                               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (base == MAP_FAILED) return NULL;
+    if (mprotect(base + pg, pg, PROT_NONE) != 0) { munmap(base, 2 * pg); return NULL; }
+    *guard = base + pg;
+    return base;
+}
+
+/* Print+flush a breadcrumb BEFORE each call so that, if clib4 does not deliver
+   SIGSEGV and the process hard-crashes, the LAST line in the output names the
+   exact routine + length that over-ran the guard. */
+#define TRY(label, expr)                                                       \
+    do {                                                                       \
+        printf("> %s len=%d (buf&15=%ld)\n", label, len, (long)(boundary & 15));\
+        fflush(stdout);                                                        \
+        g_faulted = 0;                                                         \
+        if (sigsetjmp(g_jmp, 1) == 0) { expr; }                                \
+        else { fails++; printf("[FAIL] %s OVER-RAN guard, len=%d (buf&15=%ld)\n",\
+                               label, len, (long)(boundary & 15)); }           \
+    } while (0)
+
+int main(void) {
+    long pg = sysconf(_SC_PAGESIZE);
+    if (pg <= 0) pg = 4096;
+
+    unsigned char *rg, *rpage = map_guarded(pg, &rg);   /* read buffer + guard */
+    unsigned char *wg, *wpage = map_guarded(pg, &wg);   /* write buffer + guard */
+    if (!rpage || !wpage) { perror("mmap/mprotect"); return 2; }
+
+    /* read page: non-zero everywhere (so strcpy only stops at the NUL we plant) */
+    for (long i = 0; i < pg; i++) rpage[i] = (unsigned char)((i % 255) + 1);
+
+    unsigned char *safe = malloc(pg + 64);     /* slack buffer for dst / cmp */
+    if (!safe) { perror("malloc"); return 2; }
+    memset(safe, 0x5A, pg + 64);
+
+    struct sigaction sa, old;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = on_segv;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGSEGV, &sa, &old) != 0)
+        fprintf(stderr, "warning: sigaction(SIGSEGV) failed; a fault hard-crashes\n");
+
+    const int MAXLEN = (pg < 1024) ? (int) pg - 1 : 1024;
+    int fails = 0;
+    uintptr_t boundary;
+
+    printf("altivec_guard: page=%ld; sweeping len 1..%d at a PROT_NONE boundary\n",
+           pg, MAXLEN);
+    printf("  routines under test (AltiVec on G4): bcopy memcmp strcpy bzero\n");
+    printf("  (a hard crash to the Grim Reaper instead of a report = clib4 did\n"
+           "   not deliver SIGSEGV; the crash itself is the over-run.)\n");
+
+    for (int len = 1; len <= MAXLEN; len++) {
+        if ((len & 63) == 0) fprintf(stderr, "len=%d\n", len);
+
+        /* ---- bcopy: source ends at guard (over-READ) ---- */
+        unsigned char *rsrc = rg - len;
+        boundary = (uintptr_t) rsrc;
+        TRY("bcopy",  bcopy(rsrc, safe, len));
+
+        /* ---- memcmp: 2nd buffer ends at guard; make them equal so all len
+                bytes are read (memcmp stops at first diff) (over-READ) ---- */
+        memcpy(safe, rsrc, len);                 /* scalar memcpy -> safe */
+        boundary = (uintptr_t) rsrc;
+        TRY("memcmp", (void) memcmp(safe, rsrc, len));
+
+        /* ---- strcpy: NUL-terminated string ends at guard (over-READ) ---- */
+        rg[-1] = 0;                              /* plant NUL at last readable byte */
+        {
+            char *ssrc = (char *) (rg - 1 - len); /* len non-zero chars + NUL@rg-1 */
+            boundary = (uintptr_t) ssrc;
+            TRY("strcpy", strcpy((char *) safe, ssrc));
+        }
+        rg[-1] = (unsigned char)((((pg - 1) % 255) + 1)); /* restore non-zero */
+
+        /* ---- bzero: dest ends at guard (over-WRITE) ---- */
+        unsigned char *wdst = wg - len;
+        boundary = (uintptr_t) wdst;
+        TRY("bzero",  bzero(wdst, len));
+    }
+
+    sigaction(SIGSEGV, &old, NULL);
+    printf("altivec_guard: %d failures across bcopy/memcmp/strcpy/bzero\n", fails);
+    printf("altivec_guard RESULT: %s\n", fails == 0 ? "PASS" : "FAIL");
+    return fails == 0 ? 0 : 1;
+}

--- a/test_programs/memory/memcpy_guard.c
+++ b/test_programs/memory/memcpy_guard.c
@@ -1,0 +1,160 @@
+/*
+ * memcpy_guard.c -- expose tail over-read / over-write in clib4 memcpy/memmove.
+ *
+ * Why the existing test does not catch it:
+ *   test_programs/memory/memcpy is a *benchmark*.  Its buffers carry 256 bytes
+ *   of slack after the source (std::vector<char> src(size + 256)) and it never
+ *   verifies the copied result -- so an implementation that touches a few bytes
+ *   past the end of the source (or destination) is completely invisible to it.
+ *
+ * The bug this reproduces:
+ *   clib4's AltiVec memcpy (library/cpu/altivec/vec_memcpy.sx, selected at run
+ *   time on AltiVec CPUs by clib4.c:487 `IClib4->bcopy = vec_bcopy`) uses the
+ *   classic "load two vectors + vperm" unaligned idiom, which can READ up to 15
+ *   bytes past the end of the source.  Harmless in the middle of a heap, but it
+ *   FAULTS (DSI) when the source ends just before an unmapped page -- which is
+ *   what happens copying class/string data inside a VM.  It crashed JamVM on
+ *   the QEMU 'amigaone' (G4) target: DSI at an lvx in clib4.library, DAR on a
+ *   page boundary, while loading java2d class bytes.
+ *
+ * How this test forces the failure:
+ *   It mmaps [data page][guard page] with the guard at PROT_NONE, then places
+ *   the SOURCE so it ends EXACTLY at the guard boundary (phase A) and the
+ *   DESTINATION so it ends exactly at the guard boundary (phase B).  Any read or
+ *   write one byte past the requested length hits the guard and faults.  A
+ *   SIGSEGV handler + siglongjmp lets the sweep continue and report every
+ *   offending length; it also (for the first time) checks that the copy is
+ *   actually correct.
+ *
+ *   If clib4 does NOT deliver SIGSEGV for the fault, the process hard-crashes
+ *   (Grim Reaper) at the first offending case instead of reporting -- which is
+ *   itself the proof.  The periodic "phase/len" breadcrumb on stderr narrows
+ *   down which case did it.
+ *
+ * Scope: only exercises the AltiVec path on AltiVec CPUs (G4 and the QEMU
+ *   'amigaone' machine).  On non-AltiVec CPUs (G3, 440/460, X5000/P5020,
+ *   A1222/P1022) clib4 uses scalar mem ops and this test should PASS.
+ *
+ * Build: drop in test_programs/memory/; `make compile-tests` builds it
+ *        (ppc-amigaos-gcc -mcrt=clib4 -fno-builtin ...).  PASS == rc 0.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <signal.h>
+#include <setjmp.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
+static sigjmp_buf g_jmp;
+static volatile sig_atomic_t g_faulted;
+
+static void on_segv(int sig) {
+    (void) sig;
+    g_faulted = 1;
+    siglongjmp(g_jmp, 1);       /* unwind back to the sigsetjmp in the sweep */
+}
+
+/* Map [data page][guard page]; guard is PROT_NONE so any access faults.
+   Returns the data page base (NULL on failure); *guard = the first byte that
+   must never be touched (== one past the end of the data page). */
+static unsigned char *map_guarded(long pg, unsigned char **guard) {
+    unsigned char *base = mmap(NULL, 2 * pg, PROT_READ | PROT_WRITE,
+                               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (base == MAP_FAILED)
+        return NULL;
+    if (mprotect(base + pg, pg, PROT_NONE) != 0) {
+        munmap(base, 2 * pg);
+        return NULL;
+    }
+    *guard = base + pg;
+    return base;
+}
+
+int main(void) {
+    long pg = sysconf(_SC_PAGESIZE);
+    if (pg <= 0) pg = 4096;
+
+    unsigned char *sg, *src_page = map_guarded(pg, &sg);   /* source + guard */
+    unsigned char *dg, *dst_page = map_guarded(pg, &dg);   /* dest   + guard */
+    if (!src_page || !dst_page) { perror("mmap/mprotect"); return 2; }
+
+    for (long i = 0; i < pg; i++) {
+        src_page[i] = (unsigned char)(i * 7 + 1);
+        dst_page[i] = 0;
+    }
+    unsigned char *scratch = malloc(pg + 64);
+    if (!scratch) { perror("malloc"); return 2; }
+
+    struct sigaction sa, old;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_handler = on_segv;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGSEGV, &sa, &old) != 0)
+        fprintf(stderr, "warning: sigaction(SIGSEGV) failed; a fault will hard-crash\n");
+
+    const int MAXLEN = (pg < 1024) ? (int) pg : 1024;
+    int overread = 0, overwrite = 0, miscopy = 0, cases = 0;
+
+    printf("memcpy_guard: page=%ld; sweeping len 1..%d at a PROT_NONE boundary\n",
+           pg, MAXLEN);
+    printf("  (if this hard-crashes to the Grim Reaper, clib4 did not deliver\n"
+           "   SIGSEGV and the crash itself is the over-read.)\n");
+
+    /* ---- Phase A: source ends AT the guard -> catch tail OVER-READ ---- */
+    for (int len = 1; len <= MAXLEN; len++) {
+        unsigned char *src = sg - len;             /* src + len == guard */
+        cases++;
+        if ((len & 63) == 0) { fprintf(stderr, "A len=%d\n", len); }
+        g_faulted = 0;
+        if (sigsetjmp(g_jmp, 1) == 0) {
+            memcpy(scratch, src, len);
+            if (memcmp(scratch, src, len) != 0) {
+                miscopy++;
+                printf("[FAIL] memcpy wrong result, len=%d\n", len);
+            }
+        } else {
+            overread++;
+            printf("[FAIL] memcpy OVER-READ past source end, len=%d (src&15=%ld)\n",
+                   len, (long) ((uintptr_t) src & 15));
+        }
+        g_faulted = 0;
+        if (sigsetjmp(g_jmp, 1) == 0) {
+            memmove(scratch, src, len);            /* bcopy/memmove -> same asm */
+        } else {
+            overread++;
+            printf("[FAIL] memmove OVER-READ past source end, len=%d\n", len);
+        }
+    }
+
+    /* ---- Phase B: dest ends AT the guard -> catch tail OVER-WRITE ---- */
+    for (int len = 1; len <= MAXLEN; len++) {
+        unsigned char *dst = dg - len;             /* dst + len == guard */
+        cases++;
+        if ((len & 63) == 0) { fprintf(stderr, "B len=%d\n", len); }
+        g_faulted = 0;
+        if (sigsetjmp(g_jmp, 1) == 0) {
+            memcpy(dst, src_page, len);
+            if (memcmp(dst, src_page, len) != 0) {
+                miscopy++;
+                printf("[FAIL] memcpy wrong result (B), len=%d\n", len);
+            }
+        } else {
+            overwrite++;
+            printf("[FAIL] memcpy OVER-WRITE past dest end, len=%d (dst&15=%ld)\n",
+                   len, (long) ((uintptr_t) dst & 15));
+        }
+    }
+
+    sigaction(SIGSEGV, &old, NULL);
+    printf("memcpy_guard: %d cases, over-read=%d over-write=%d miscopy=%d\n",
+           cases, overread, overwrite, miscopy);
+    int ok = (overread == 0 && overwrite == 0 && miscopy == 0);
+    printf("memcpy_guard RESULT: %s\n", ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Issue Description

On AltiVec-equipped PowerPC (G4 / MPC744x/745x), `strcpy()` — which clib4 routes
to the AltiVec `vec_strcpy` at runtime — can read **past the end of the source
page** and take a DSI (Data Storage Interrupt) when the source string ends close
to a 4K page boundary and the next page is unmapped. The result is a hard crash
(Grim Reaper) inside `clib4.library`.

It is intermittent in normal code but reproduces reliably whenever short strings
are copied out of buffers that end near a page boundary — e.g. a VM interning
class-name strings. It was first hit by a JamVM-based Java runtime copying
class-name UTF-8 strings during class loading on a 7447/7457 G4:

```
Crash occured in module clib4.library at address 0x7F9CB40C
Type of crash: DSI (Data Storage Interrupt) exception
  ...
*7f9cb40c: 7c4050ce   lvx   v2,r0,r10      ; r10 -> the guard (unmapped) page
CPU Model: Motorola MPC 7447/7457 Apollo (Extensions: altivec)
```

## Cause

`vec_strcpy` (`library/cpu/altivec/vec_strcpy.sx`, the Motorola/Chuck Corley
AltiVec reference routine) speculatively loads source vectors ahead of the NUL
terminator and is supposed to guard against crossing a 4K page so it never
faults on an unmapped page. The guard was wrong in two ways:

1. **It was computed from the destination, not the source.** The faulting `lvx`
   loads read from the SOURCE (`DS`), but the "QWs to next page" counter (`PBC`)
   was derived from the DESTINATION pointer (`DD`):

   ```
   addi   ADD,DD,PAGE_SIZE   ; dest's next 4K page
   ...
   subf.  PBC,DD,ADD         ; QWs from dest to the DEST's page boundary
   ```

   The destination is QW-aligned, so the count is exact *for the dest* — but it
   has no relation to where the source sits in its own page. For the common case
   `strcpy(fresh_buffer, string_ending_near_a_page_end)` the destination is
   mid-page, so the counter is far too large and the loop keeps loading source
   vectors straight into the next (possibly unmapped) page.

2. **The source pointer is not QW-aligned.** `lvx` ignores the low 4 address
   bits (it loads `DS & ~15`). A naive source-based `(page - DS) / 16` rounds
   *down*: when the source is fewer than 16 bytes from its page boundary the
   count becomes 0, which falls through to the `New_page_0` path that reloads a
   *whole page* and over-reads anyway.

## Solution

Compute the page-crossing guard from the **source**, using the **QW-aligned**
source address (matching what `lvx` actually loads):

```diff
-	addi	ADD,DD,PAGE_SIZE	// dst addr in next 4K page
+	addi	ADD,SRC,PAGE_SIZE	// SRC addr in next 4K page (loads fault on src)
 ...
-	subf.	PBC,DD,ADD	// Now bytes to next 4K page (from dest)
+	rlwinm	Rt,DS,0,0,27	// align src down to QW (lvx loads use DS&~15)
+	subf.	PBC,Rt,ADD	// QW-exact bytes from aligned src to its page boundary
```

The loop now pauses exactly at the source's page boundary, checks the last
in-page vector for the NUL (which is present, because the string ends in that
page), and finishes the tail byte-by-byte — never reading into the next page.
AltiVec acceleration is preserved (no fallback to scalar).

The length-bounded AltiVec routines (`vec_memcpy`/`vec_memcmp`/`vec_bcopy`/
`vec_bzero`) cannot over-read this way and are verified clean (see Testing).
The length-*unbounded* scanners `vec_strchr`/`vec_memchr` (currently behind
`SLOWER_ALTIVEC_FUNCTIONS`) deserve the same review if they are ever enabled.

## Testing

> **Verified under emulation — no physical AltiVec hardware was available.** The
> tests were built and run under **QEMU** (`qemu-system-ppc -M amigaone`), whose
> CPU model emulates a **Motorola MPC 7447/7457 (G4) with AltiVec**. QEMU
> executes the real AltiVec instructions (`lvx`/`vperm`) and emulates the MMU
> page fault, so the AltiVec `vec_strcpy` path and the page-boundary DSI are
> genuinely exercised (not stubbed) — but a confirmation on real G4 silicon would
> be welcome.

Adds two guard-page tests under `test_programs/memory/` (auto-built by
`make compile-tests`, which compiles with `-fno-builtin` so the calls reach
clib4's routines). Each `mmap`s a `[data page][PROT_NONE guard page]` pair and
places the buffer so it ends exactly at the guard, so any read or write one byte
past the requested length faults immediately. A `SIGSEGV` handler reports the
offending routine + length; if the fault is not delivered as a signal, a flushed
breadcrumb names the last call attempted.

* **`altivec_guard.c`** — sweeps the AltiVec-routed routines (`bcopy`, `memcmp`,
  `strcpy`, `bzero`) over lengths 1..1024 with the buffer at the guard boundary.
* **`memcpy_guard.c`** — same technique for `memcpy`/`memmove`, plus a
  correctness check for them.

**How it was run:** built with `make compile-tests`, deployed the resulting ELF
to the AmigaOS 4.1 guest, and launched from the Amiga Shell via `Run` (so it gets
a CLI process), with output captured to a file. The rebuilt `clib4.library`
(carrying this fix) was installed to `LIBS:` and loaded with a reboot.

Result on the emulated G4:

| `altivec_guard` | Result |
|---|---|
| **Before** | DSI crash at `strcpy len=16` (`lvx` into the guard page; confirmed in the Grim Reaper crash log — `lvx v2,r0,r10` with `r10` pointing at the guard) |
| **After**  | **RESULT: PASS** — 0 failures across `bcopy`/`memcmp`/`strcpy`/`bzero` × len 1..1024 |

`memcpy_guard` passes before and after (clib4 routes `memcpy`/`memmove` to the
scalar path). The Java runtime that originally surfaced the crash no longer
faults during class loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
