### PR TITLE
optimize: Cache Clib4Resource pointer to eliminate repeated OpenResource() calls in malloc

### DIFF
--- a/library/dos.h
+++ b/library/dos.h
@@ -603,6 +603,14 @@ struct _clib4 {
      */
     struct iob   *__sf[3];              /* per-process stdin/stdout/stderr iob pointers */
     struct _glue *__sglue;              /* per-process root glue node for FILE slots */
+
+    /*
+     * Cached pointer to the global Clib4Resource.
+     * Initialized once in stdlib_memory_init to avoid repeated OpenResource() calls
+     * in malloc/free hot path. The resource itself is shared across all processes,
+     * but each process caches its own pointer for fast access.
+     */
+    struct Clib4Resource *__clib4_resource;
 };
 
 #ifndef __getClib4

--- a/library/stdlib/malloc.c
+++ b/library/stdlib/malloc.c
@@ -18,9 +18,8 @@
 
 wmem_allocator_t *
 __get_wmem_allocator(struct _clib4 *__clib4) {
-    (void) __clib4;
-
-    struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
+    /* Use cached resource pointer - initialized in stdlib_memory_init */
+    struct Clib4Resource *res = __clib4->__clib4_resource;
     if (res == NULL)
         return NULL;
 
@@ -71,7 +70,8 @@ out:
 }
 
 void __memory_lock(struct _clib4 *__clib4) {
-    struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
+    /* Use cached resource pointer - initialized in stdlib_memory_init */
+    struct Clib4Resource *res = __clib4->__clib4_resource;
 
     if(__clib4->memory_mutex)
         MutexObtain(__clib4->memory_mutex);
@@ -81,7 +81,8 @@ void __memory_lock(struct _clib4 *__clib4) {
 }
 
 void __memory_unlock(struct _clib4 *__clib4) {
-    struct Clib4Resource *res = (APTR) OpenResource(RESOURCE_NAME);
+    /* Use cached resource pointer - initialized in stdlib_memory_init */
+    struct Clib4Resource *res = __clib4->__clib4_resource;
 
     if (res != NULL)
         ReleaseSemaphore(&res->semaphore);
@@ -98,6 +99,9 @@ STDLIB_DESTRUCTOR(stdlib_memory_exit) {
         __delete_mutex(__clib4->memory_mutex);
         __clib4->memory_mutex = NULL;
     }
+
+    /* Clear cached resource pointer */
+    __clib4->__clib4_resource = NULL;
 
     LEAVE();
 }
@@ -120,6 +124,9 @@ STDLIB_CONSTRUCTOR(stdlib_memory_init) {
         __clib4->memory_mutex = NULL;
         goto out;
     }
+
+    /* Cache the global resource pointer to avoid repeated OpenResource() calls */
+    __clib4->__clib4_resource = res;
 
     ObtainSemaphore(&res->semaphore);
     if (res->__wmem_allocator == NULL) {


### PR DESCRIPTION
- Add __clib4_resource field to struct _clib4 for caching the global resource pointer
- Initialize cache once in stdlib_memory_init instead of calling OpenResource() on every allocation
- Update __get_wmem_allocator, __memory_lock, and __memory_unlock to use cached pointer
- Eliminates 3 OpenResource() calls per malloc/free (hot path optimization)
- Maintains global allocator semantics and thread-safety through shared resource semaphore