### PR TITLE
stdlib: implement malloc_usable_size()

### DIFF
--- a/libc.gmk
+++ b/libc.gmk
@@ -532,6 +532,7 @@ C_STDLIB := \
 	stdlib/lltoa.o \
 	stdlib/main.o \
 	stdlib/malloc.o \
+	stdlib/malloc_usable_size.o \
 	stdlib/mblen.o \
 	stdlib/mbstowcs.o \
 	stdlib/mbtowc.o \

--- a/library/c.lib_rev.h
+++ b/library/c.lib_rev.h
@@ -1,7 +1,7 @@
 #define VERSION			2
 #define REVISION		1
 
-#define DATE			"19.06.2026"
+#define DATE			"11.07.2026"
 #define VERS			"clib4.library 2.1"
-#define VSTRING			"clib4.library 2.1 (19.06.2026)\r\n"
-#define VERSTAG			"\0$VER: clib4.library 2.1-nightly-c971606 (19.06.2026)"
+#define VSTRING			"clib4.library 2.1 (11.07.2026)\r\n"
+#define VERSTAG			"\0$VER: clib4.library 2.1-nightly-c971606 (11.07.2026)"

--- a/library/include/malloc.h
+++ b/library/include/malloc.h
@@ -18,6 +18,9 @@ __BEGIN_DECLS
 /* Allocate SIZE bytes allocated to ALIGNMENT bytes.  */
 extern void *memalign(size_t alignment, size_t size);
 
+/* Return the usable size of a block allocated by malloc(). */
+extern size_t malloc_usable_size(void *ptr);
+
 __END_DECLS
 
 #endif //_MALLOC_H

--- a/library/shared_library/clib4_vectors.h
+++ b/library/shared_library/clib4_vectors.h
@@ -1202,5 +1202,7 @@ static void *clib4Vectors[] = {
         (void *) (mlockall),                              /* 4480 */
         (void *) (munlockall),                            /* 4484 */
         (void *) (mlock2),                                /* 4488 */
+
+        (void *) (malloc_usable_size),                    /* 4492 */
         (void *)-1
 };

--- a/library/shared_library/interface.h
+++ b/library/shared_library/interface.h
@@ -1370,11 +1370,13 @@ struct Clib4IFace {
 	char * (* canonicalize_file_name) (const char *name);																	 						 /* 4460 */
 	int (* spawnvpe_fork) (const char *file, const char **argv, char **deltaenv, const char *dir, int fhin, int fhout, int fherr);                   /* 4464 */
 	int (* mprotect) (void *addr, size_t len, int prot);                                                                                             /* 4468 */
-    int (* mlock) (const void *addr, size_t len);                                                                                                     /* 4472 */
-    int (* munlock) (const void *addr, size_t len);                                                                                                   /* 4476 */
-    int (* mlockall) (int flags);                                                                                                                     /* 4480 */
-    int (* munlockall) (void);                                                                                                                        /* 4484 */
+    int (* mlock) (const void *addr, size_t len);                                                                                                    /* 4472 */
+    int (* munlock) (const void *addr, size_t len);                                                                                                  /* 4476 */
+    int (* mlockall) (int flags);                                                                                                                    /* 4480 */
+    int (* munlockall) (void);                                                                                                                       /* 4484 */
     int (* mlock2) (const void *addr, size_t len, unsigned int flags);                                                                               /* 4488 */
+
+    size_t (* malloc_usable_size) (void *ptr);                                                                                                       /* 4492 */
 };
 
 #ifdef __PIC__

--- a/library/shared_library/stubs_malloc_usable_size.c
+++ b/library/shared_library/stubs_malloc_usable_size.c
@@ -1,0 +1,2 @@
+#include "stubs_common.h"
+Clib4Call(malloc_usable_size, 4492);

--- a/library/stdlib/malloc_usable_size.c
+++ b/library/stdlib/malloc_usable_size.c
@@ -1,0 +1,41 @@
+/*
+ * $Id: stdlib_malloc_usable_size.c,v 1.0 2024-01-01 00:00:00 clib4devs Exp $
+*/
+
+#ifndef _STDLIB_HEADERS_H
+#include "stdlib_headers.h"
+#endif /* _STDLIB_HEADERS_H */
+
+#ifndef _STDLIB_MEMORY_H
+#include "stdlib_memory.h"
+#endif /* _STDLIB_MEMORY_H */
+
+#include <malloc.h>
+
+size_t
+__malloc_usable_size_r(struct _clib4 *__clib4, const void *ptr) {
+    size_t result = 0;
+    wmem_allocator_t *allocator;
+
+    if (ptr == NULL || __clib4 == NULL)
+        return 0;
+
+    __memory_lock(__clib4);
+
+    allocator = __get_wmem_allocator(__clib4);
+    if (allocator == NULL) {
+        __memory_unlock(__clib4);
+        return 0;
+    }
+
+    result = wmem_alloc_size(allocator, ptr);
+
+    __memory_unlock(__clib4);
+
+    return result;
+}
+
+size_t
+malloc_usable_size(void *ptr) {
+    return __malloc_usable_size_r(__CLIB4, ptr);
+}

--- a/library/stdlib/stdlib_protos.h
+++ b/library/stdlib/stdlib_protos.h
@@ -86,6 +86,7 @@ extern void __srandom(unsigned seed);
 extern void *__malloc_r(struct _clib4 *__clib4, size_t size);
 extern void *__malloc_aligned_r(struct _clib4 *__clib4, size_t size, int32_t alignment);
 extern void *__calloc_r(struct _clib4 *__clib4, size_t num_elements, size_t element_size);
+extern size_t __malloc_usable_size_r(struct _clib4 *__clib4, const void *ptr);
 
 extern uint32_t lcg31(uint32_t x);
 extern uint64_t lcg64(uint64_t x);

--- a/library/wmem/wmem_allocator.h
+++ b/library/wmem/wmem_allocator.h
@@ -30,6 +30,7 @@ struct _wmem_allocator_t {
     void *(*walloc)(void *private_data, const size_t size, int32_t alignment);
     void  (*wfree)(void *private_data, void *ptr);
     void *(*wrealloc)(void *private_data, void *ptr, const size_t size, int32_t alignment);
+    size_t (*wsize)(void *private_data, const void *ptr);
 
     /* Producer/Manager functions */
     void  (*free_all)(void *private_data);

--- a/library/wmem/wmem_allocator_block.c
+++ b/library/wmem/wmem_allocator_block.c
@@ -886,6 +886,13 @@ wmem_block_realloc_jumbo(wmem_block_allocator_t *allocator,
 
 /* API */
 
+static size_t
+wmem_block_size(void *private_data, const void *ptr) {
+    (void) private_data;
+    wmem_block_chunk_t *chunk = WMEM_DATA_TO_PRE(ptr)->chunk;
+    return chunk->len - ((uintptr_t)ptr - (uintptr_t)chunk);
+}
+
 static void *
 wmem_block_alloc(void *private_data, const size_t size, int32_t alignment) {
     wmem_block_allocator_t *allocator = (wmem_block_allocator_t *) private_data;
@@ -1191,6 +1198,7 @@ wmem_block_allocator_init(wmem_allocator_t *allocator) {
     allocator->walloc = &wmem_block_alloc;
     allocator->wrealloc = &wmem_block_realloc;
     allocator->wfree = &wmem_block_free;
+    allocator->wsize = &wmem_block_size;
 
     allocator->free_all = &wmem_block_free_all;
     allocator->gc = &wmem_block_gc;

--- a/library/wmem/wmem_allocator_block_fast.c
+++ b/library/wmem/wmem_allocator_block_fast.c
@@ -160,6 +160,13 @@ wmem_block_fast_free(void *private_data, void *ptr) {
     /* free is NOP */
 }
 
+static size_t
+wmem_block_fast_size(void *private_data, const void *ptr) {
+    (void) private_data;
+    wmem_block_fast_chunk_t *chunk = WMEM_DATA_TO_CHUNK(ptr);
+    return chunk->size;
+}
+
 static void *
 wmem_block_fast_realloc(void *private_data, void *ptr, const size_t size, int32_t alignment) {
     wmem_block_fast_chunk_t *chunk;
@@ -273,6 +280,7 @@ wmem_block_fast_allocator_init(wmem_allocator_t *allocator) {
     allocator->walloc = &wmem_block_fast_alloc;
     allocator->wrealloc = &wmem_block_fast_realloc;
     allocator->wfree = &wmem_block_fast_free;
+    allocator->wsize = &wmem_block_fast_size;
 
     allocator->free_all = &wmem_block_fast_free_all;
     allocator->gc = &wmem_block_fast_gc;

--- a/library/wmem/wmem_allocator_simple.c
+++ b/library/wmem/wmem_allocator_simple.c
@@ -166,6 +166,16 @@ wmem_simple_realloc(void *private_data, void *ptr, const size_t size, int32_t al
     return NULL;
 }
 
+static size_t
+wmem_simple_size(void *private_data, const void *ptr) {
+    wmem_simple_allocator_t *allocator = (wmem_simple_allocator_t *) private_data;
+    for (int i = allocator->count - 1; i >= 0; i--) {
+        if (ptr == allocator->ptrs[i])
+            return allocator->sizes[i];
+    }
+    return 0;
+}
+
 static void
 wmem_simple_free_all(void *private_data) {
     wmem_simple_allocator_t *allocator;
@@ -211,6 +221,7 @@ wmem_simple_allocator_init(wmem_allocator_t *allocator) {
     allocator->walloc = &wmem_simple_alloc;
     allocator->wrealloc = &wmem_simple_realloc;
     allocator->wfree = &wmem_simple_free;
+    allocator->wsize = &wmem_simple_size;
 
     allocator->free_all = &wmem_simple_free_all;
     allocator->gc = &wmem_simple_gc;

--- a/library/wmem/wmem_allocator_strict.c
+++ b/library/wmem/wmem_allocator_strict.c
@@ -211,6 +211,13 @@ wmem_strict_allocator_cleanup(void *private_data) {
     wmem_free(NULL, private_data);
 }
 
+static size_t
+wmem_strict_size(void *private_data, const void *ptr) {
+    wmem_strict_allocator_t *allocator = (wmem_strict_allocator_t *) private_data;
+    wmem_strict_allocator_block_t *block = WMEM_DATA_TO_BLOCK(allocator, (void*)ptr);
+    return block ? block->data_len : 0;
+}
+
 void
 wmem_strict_allocator_init(wmem_allocator_t *allocator) {
     wmem_strict_allocator_t *strict_allocator;
@@ -220,6 +227,7 @@ wmem_strict_allocator_init(wmem_allocator_t *allocator) {
     allocator->walloc = &wmem_strict_alloc;
     allocator->wrealloc = &wmem_strict_realloc;
     allocator->wfree = &wmem_strict_free;
+    allocator->wsize = &wmem_strict_size;
 
     allocator->free_all = &wmem_strict_free_all;
     allocator->gc = &wmem_strict_gc;

--- a/library/wmem/wmem_core.c
+++ b/library/wmem/wmem_core.c
@@ -214,6 +214,16 @@ wmem_realloc(wmem_allocator_t *allocator, void *ptr, const size_t size) {
     return wmem_realloc_aligned(allocator, ptr, size, 16);
 }
 
+size_t
+wmem_alloc_size(wmem_allocator_t *allocator, const void *ptr) {
+    if (allocator == NULL || ptr == NULL || allocator->wsize == NULL)
+        return 0;
+
+    assert(allocator->in_scope);
+
+    return allocator->wsize(allocator->private_data, ptr);
+}
+
 static void
 wmem_free_all_real(wmem_allocator_t *allocator, bool final) {
     wmem_call_callbacks(allocator,

--- a/library/wmem/wmem_core.h
+++ b/library/wmem/wmem_core.h
@@ -147,6 +147,14 @@ extern void * wmem_alloc0(wmem_allocator_t *allocator, const size_t size) __attr
  */
 extern void wmem_free(wmem_allocator_t *allocator, void *ptr);
 
+/** Returns the usable size of a previously allocated block.
+ *
+ * @param allocator The allocator object used to originally allocate the memory.
+ * @param ptr The pointer to the memory block.
+ * @return The usable size in bytes of the block, or 0 if unknown/invalid.
+ */
+extern size_t wmem_alloc_size(wmem_allocator_t *allocator, const void *ptr);
+
 /** Resizes a block of memory, potentially moving it if resizing it in place
  * is not possible.
  *

--- a/test_programs/memory/malloc_usable_size.c
+++ b/test_programs/memory/malloc_usable_size.c
@@ -1,0 +1,154 @@
+/*
+ * Test program for malloc_usable_size()
+ *
+ * Verifies that malloc_usable_size() returns a value >= the requested
+ * allocation size for various allocation sizes and patterns.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <malloc.h>
+
+static int failed = 0;
+
+#define CHECK(cond, fmt, ...) \
+    do { \
+        if (!(cond)) { \
+            fprintf(stderr, "FAIL: " fmt "\n", ##__VA_ARGS__); \
+            failed++; \
+        } else { \
+            printf("PASS: " fmt "\n", ##__VA_ARGS__); \
+        } \
+    } while (0)
+
+static void
+test_basic_sizes(void) {
+    static const size_t sizes[] = { 1, 7, 8, 15, 16, 32, 63, 64, 128, 255,
+                                    256, 512, 1024, 4096, 65536, 1048576 };
+    size_t n = sizeof(sizes) / sizeof(sizes[0]);
+
+    printf("\n--- Basic size tests ---\n");
+    for (size_t i = 0; i < n; i++) {
+        size_t req = sizes[i];
+        void *p = malloc(req);
+        CHECK(p != NULL, "malloc(%zu) succeeded", req);
+        if (!p) continue;
+
+        size_t usable = malloc_usable_size(p);
+        CHECK(usable >= req,
+              "malloc_usable_size for req=%zu => usable=%zu (>= req)",
+              req, usable);
+
+        /* Make sure we can actually write usable bytes without crashing. */
+        memset(p, 0xAB, usable);
+
+        free(p);
+    }
+}
+
+static void
+test_null_ptr(void) {
+    printf("\n--- NULL pointer test ---\n");
+    size_t usable = malloc_usable_size(NULL);
+    CHECK(usable == 0, "malloc_usable_size(NULL) == 0 (got %zu)", usable);
+}
+
+static void
+test_realloc(void) {
+    printf("\n--- realloc test ---\n");
+    void *p = malloc(64);
+    CHECK(p != NULL, "malloc(64) succeeded");
+    if (!p) return;
+
+    size_t before = malloc_usable_size(p);
+    CHECK(before >= 64, "usable before realloc >= 64 (got %zu)", before);
+
+    p = realloc(p, 256);
+    CHECK(p != NULL, "realloc(p, 256) succeeded");
+    if (!p) return;
+
+    size_t after = malloc_usable_size(p);
+    CHECK(after >= 256, "usable after realloc(256) >= 256 (got %zu)", after);
+
+    free(p);
+}
+
+static void
+test_calloc(void) {
+    printf("\n--- calloc test ---\n");
+    void *p = calloc(10, 32);
+    CHECK(p != NULL, "calloc(10, 32) succeeded");
+    if (!p) return;
+
+    size_t usable = malloc_usable_size(p);
+    CHECK(usable >= 10 * 32,
+          "malloc_usable_size after calloc(10,32) >= 320 (got %zu)", usable);
+    free(p);
+}
+
+static void
+test_aligned_alloc(void) {
+    printf("\n--- aligned_alloc test ---\n");
+    static const size_t alignments[] = { 16, 32, 64, 128 };
+    for (size_t i = 0; i < sizeof(alignments)/sizeof(alignments[0]); i++) {
+        size_t align = alignments[i];
+        void *p = aligned_alloc(align, 256);
+        CHECK(p != NULL, "aligned_alloc(%zu, 256) succeeded", align);
+        if (!p) continue;
+
+        CHECK(((uintptr_t)p & (align - 1)) == 0,
+              "aligned_alloc(%zu) ptr is properly aligned", align);
+
+        size_t usable = malloc_usable_size(p);
+        CHECK(usable >= 256,
+              "malloc_usable_size after aligned_alloc(%zu,256) >= 256 (got %zu)",
+              align, usable);
+        free(p);
+    }
+}
+
+static void
+test_many_allocs(void) {
+    printf("\n--- Many simultaneous allocations ---\n");
+    enum { N = 128 };
+    void *ptrs[N];
+    size_t req_sizes[N];
+
+    for (int i = 0; i < N; i++) {
+        req_sizes[i] = (size_t)(i + 1) * 17;
+        ptrs[i] = malloc(req_sizes[i]);
+    }
+
+    int all_ok = 1;
+    for (int i = 0; i < N; i++) {
+        if (!ptrs[i]) { all_ok = 0; continue; }
+        size_t usable = malloc_usable_size(ptrs[i]);
+        if (usable < req_sizes[i]) {
+            fprintf(stderr, "FAIL: alloc[%d] req=%zu usable=%zu\n",
+                    i, req_sizes[i], usable);
+            all_ok = 0;
+            failed++;
+        }
+    }
+    if (all_ok)
+        printf("PASS: all %d allocations have usable >= requested\n", N);
+
+    for (int i = 0; i < N; i++)
+        if (ptrs[i]) free(ptrs[i]);
+}
+
+int
+main(void) {
+    printf("=== malloc_usable_size() test ===\n");
+
+    test_null_ptr();
+    test_basic_sizes();
+    test_realloc();
+    test_calloc();
+    test_aligned_alloc();
+    test_many_allocs();
+
+    printf("\n=== Result: %s ===\n", failed ? "FAILED" : "PASSED");
+    return failed ? 1 : 0;
+}


### PR DESCRIPTION
Add malloc_usable_size() using the existing wmem allocator metadata:

- wmem: add wsize() function pointer to _wmem_allocator_t vtable
- wmem: implement wmem_block_size() in O(1) via wmem_block_pre_t/chunk->len
- wmem: implement wmem_block_fast_size() in O(1) via chunk->size
- wmem: implement wmem_simple_size() via sizes[] array scan
- wmem: implement wmem_strict_size() via blocks list scan
- wmem: expose wmem_alloc_size() public API in wmem_core.c/h
- stdlib: add malloc_usable_size.c with malloc_usable_size() / __malloc_usable_size_r()
- include: declare malloc_usable_size() in malloc.h
- test: add test_programs/memory/malloc_usable_size.c