### PR TITLE
Replace ctor/dtor priority mechanism with direct init/exit calls

### DIFF
--- a/library/amiga/rexxvars.c
+++ b/library/amiga/rexxvars.c
@@ -16,6 +16,9 @@
 #include <rexx/rxslib.h>
 #include <rexx/errors.h>
 
+void __attribute__((constructor, used)) rexxvars_init_ctor();
+void __attribute__((destructor, used)) rexxvars_exit_dtor();
+
 /* This is used by the stub function prototypes. The ARexx header files
    do not define it, though. */
 struct Environment;
@@ -32,8 +35,7 @@ LONG SetRexxVar(struct RexxMsg *message, STRPTR variable_name, STRPTR value, LON
 
 /****************************************************************************/
 
-CLIB_CONSTRUCTOR(rexxvars_init)
-{
+void rexxvars_init_ctor(void) {
 	ENTER();
 
 	RexxSysBase = OpenLibrary(RXSNAME, 0);
@@ -49,12 +51,9 @@ CLIB_CONSTRUCTOR(rexxvars_init)
 	}
 
 	LEAVE();
-
-	CONSTRUCTOR_SUCCEED();
 }
 
-CLIB_DESTRUCTOR(rexxvars_exit)
-{
+void rexxvars_exit_dtor(void) {
 	ENTER();
 
 	if (IRexxSys != NULL)

--- a/library/dirent/closedir.c
+++ b/library/dirent/closedir.c
@@ -24,7 +24,7 @@ void __dirent_unlock(struct _clib4 *__clib4) {
         ReleaseSemaphore(__clib4->dirent_lock);
 }
 
-CLIB_CONSTRUCTOR(dirent_init) {
+void dirent_init(void) {
     BOOL success = FALSE;
     struct _clib4 *__clib4 = __CLIB4;
 
@@ -49,7 +49,7 @@ out:
         CONSTRUCTOR_FAIL();
 }
 
-CLIB_DESTRUCTOR(dirent_exit) {
+void dirent_exit(void) {
     ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 

--- a/library/locale/dcngettext.c
+++ b/library/locale/dcngettext.c
@@ -778,7 +778,7 @@ char *bind_textdomain_codeset(const char *domainname, const char *codeset) {
     return NULL;
 }
 
-CLIB_DESTRUCTOR(dcngettext_exit) {
+void dcngettext_exit(void) {
     struct _clib4 *__clib4 = __CLIB4;
     /* Free binddtextdomain bindings */
     if (__clib4->g_mofile) {

--- a/library/locale/init_exit.c
+++ b/library/locale/init_exit.c
@@ -134,7 +134,7 @@ void __locale_unlock(struct _clib4 *__clib4) {
 		ReleaseSemaphore(__clib4->locale_lock);
 }
 
-CLIB_DESTRUCTOR(locale_exit) {
+void locale_exit(void) {
 	ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 
@@ -149,7 +149,7 @@ CLIB_DESTRUCTOR(locale_exit) {
     LEAVE();
 }
 
-CLIB_CONSTRUCTOR(locale_init) {
+void locale_init(void) {
 	BOOL success = FALSE;
 	int i;
     struct _clib4 *__clib4 = __CLIB4;

--- a/library/math/init_exit.c
+++ b/library/math/init_exit.c
@@ -27,7 +27,7 @@ __setfpucw(fpu_control_t set) {
     _FPU_SETCW (cw);
 }
 
-MATH_CONSTRUCTOR(math_init) {
+void math_init(void) {
     union ieee_single *single_x;
     struct _clib4 *__clib4 = __CLIB4;
 

--- a/library/pthread/pthread.c
+++ b/library/pthread/pthread.c
@@ -569,7 +569,7 @@ void __pthread_exit_func(void) {
 }
 
 
-PTHREAD_CONSTRUCTOR(__pthread_init) {
+void __pthread_init(void) {
     ENTER();
     SHOWMSG("[__pthread_init :] Pthread constructor called.\n");
     _DOSBase = OpenLibrary("dos.library", MIN_OS_VERSION);
@@ -585,7 +585,7 @@ PTHREAD_CONSTRUCTOR(__pthread_init) {
     LEAVE();
 }
 
-PTHREAD_DESTRUCTOR(__pthread_exit) {
+void __pthread_exit(void) {
     ENTER();
     SHOWMSG("[__pthread_exit :] Pthread destructor called.\n");
 

--- a/library/rt/aio_init.c
+++ b/library/rt/aio_init.c
@@ -12,6 +12,9 @@
 #include <aio.h>
 #include "aio_misc.h"
 
+void __attribute__((constructor, used)) aio_init_ctor();
+void __attribute__((destructor, used)) aio_exit_dtor();
+
 /* Used by aio functions */
 struct SignalSemaphore *__aio_lock;
 CList *aio_threads;
@@ -22,7 +25,7 @@ void aio_init(const struct aioinit *init) {
 }
 #endif
 
-CLIB_CONSTRUCTOR(aio_init) {
+void aio_init_ctor(void) {
     ENTER();
 
     /* Initialize aio pthread list */
@@ -40,7 +43,7 @@ out:
     LEAVE();
 }
 
-CLIB_DESTRUCTOR(aio_exit) {
+void aio_exit_dtor(void) {
     ENTER();
 
     if (__aio_lock == NULL || aio_threads == NULL) {

--- a/library/shared_library/clib4.c
+++ b/library/shared_library/clib4.c
@@ -91,11 +91,9 @@
 #include "interface.h"
 #include "stdlib_protos.h"
 
-/* These CTORS/DTORS are clib4's one and they are different than that one received
- * from crtbegin. They are needed because we need to call clib4 constructors as well
- */
-static void (*__CTOR_LIST__[1])(void) __attribute__((section(".ctors")));
-static void (*__DTOR_LIST__[1])(void) __attribute__((section(".dtors")));
+#ifndef _STDLIB_CONSTRUCTOR_H
+#include "stdlib_constructor.h"
+#endif /* _STDLIB_CONSTRUCTOR_H */
 
 /* This is variable defines where to start to bind unix local ports using inet addresses */
 struct UnixSocket {
@@ -172,18 +170,91 @@ struct envHookData {
 
 static char *empty_env[1] = {NULL};
 
+/* clib4 initialization functions, called directly in a fixed order that
+ * matches the historical constructor priorities (see stdlib_constructor.h).
+ * No constructor/destructor attributes are used anymore, so no other
+ * library with a same or lower constructor priority can run in between
+ * clib4's own initialization steps. */
 static void
-_start_ctors(void (*__CTOR_LIST__[])(void)) {
-    int i = 0;
+clib4_init(void) {
+    SHOWMSG("Calling stdlib_memory_init");
+    stdlib_memory_init();          /* STDLIB - memory allocator */
 
-    while (__CTOR_LIST__[i + 1]) {
-        i++;
-    }
-    SHOWVALUE(i);
-    while (i > 0) {
-        D(("Calling ctor %ld", i));
-        __CTOR_LIST__[i--]();
-    }
+    SHOWMSG("Calling stdio_init");
+    stdio_init();                  /* STDIO */
+
+    SHOWMSG("Calling stdio_file_init");
+    stdio_file_init();             /* FILE - standard I/O streams */
+
+    SHOWMSG("Calling math_init");
+    math_init();                   /* MATH */
+
+    SHOWMSG("Calling socket_init");
+    socket_init();                 /* SOCKET */
+
+    SHOWMSG("Calling locale_init");
+    locale_init();                 /* CLIB */
+
+    SHOWMSG("Calling usergroup_init");
+    usergroup_init();              /* CLIB */
+
+    SHOWMSG("Calling timezone_init");
+    timezone_init();               /* CLIB */
+
+    SHOWMSG("Calling unistd_init");
+    unistd_init();                 /* CLIB */
+
+    SHOWMSG("Calling timer_init");
+    timer_init();                  /* CLIB - must run before clock_init (gettimeofday) */
+
+    SHOWMSG("Calling clock_init");
+    clock_init();                  /* CLIB */
+
+    SHOWMSG("Calling dirent_init");
+    dirent_init();                 /* CLIB */
+}
+
+/* clib4 cleanup functions, called in the exact reverse order of clib4_init() */
+static void
+clib4_exit(void) {
+    SHOWMSG("Calling dirent_exit");
+    dirent_exit();                 /* CLIB */
+
+    SHOWMSG("Calling timer_exit");
+    timer_exit();                  /* CLIB */
+
+    SHOWMSG("Calling unistd_exit");
+    unistd_exit();                 /* CLIB */
+
+    SHOWMSG("Calling __wildcard_expand_exit");
+    __wildcard_expand_exit();      /* CLIB */
+
+    SHOWMSG("Calling __chdir_exit");
+    __chdir_exit();                /* CLIB */
+
+    SHOWMSG("Calling __setenv_exit");
+    __setenv_exit();               /* CLIB */
+
+    SHOWMSG("Calling dcngettext_exit");
+    dcngettext_exit();             /* CLIB */
+
+    SHOWMSG("Calling timezone_exit");
+    timezone_exit();               /* CLIB */
+
+    SHOWMSG("Calling usergroup_exit");
+    usergroup_exit();              /* CLIB */
+
+    SHOWMSG("Calling locale_exit");
+    locale_exit();                 /* CLIB */
+
+    SHOWMSG("Calling socket_exit");
+    socket_exit();                 /* SOCKET */
+
+    SHOWMSG("Calling stdio_exit");
+    stdio_exit();                  /* STDIO */
+
+    SHOWMSG("Calling stdlib_memory_exit");
+    stdlib_memory_exit();          /* STDLIB - memory allocator, always last */
 }
 
 static void
@@ -548,8 +619,8 @@ struct Clib4Library *libOpen(struct LibraryManagerInterface *Self, uint32 versio
             me->pr_UID = (uint32) __clib4;
             //SetOwnerInfoTags(OI_ProcessInput, 0, OI_OwnerUID, __clib4, TAG_END);
 
-            /* Check if user has choosen a different memory allocator and this needs to be called before constructors
-             * sice malloc constructor will use __wof_mem_allocator_type field
+            /* Check if user has choosen a different memory allocator and this needs to be called before
+             * clib4_init since stdlib_memory_init will use __wof_mem_allocator_type field
              */
             SHOWMSG("Check for custom memory allocator");
             if ((len = IDOS->GetVar("CLIB4_MEMORY_ALLOCATOR", envbuf, sizeof(envbuf), 0)) >= 0) {
@@ -564,13 +635,13 @@ struct Clib4Library *libOpen(struct LibraryManagerInterface *Self, uint32 versio
                 // else leave the default one
             }
 
-            /* After reent structure we can call clib4 constructors */
-            SHOWMSG("Calling clib4 ctors");
-            _start_ctors(__CTOR_LIST__);
-            SHOWMSG("Done. All constructors called");
+            /* After reent structure we can initialize clib4 subsystems */
+            SHOWMSG("Calling clib4 init functions");
+            clib4_init();
+            SHOWMSG("Done. All init functions called");
 
             /* Import any file descriptors inherited from the parent process.
-             * Must be done AFTER _start_ctors (which runs stdio_file_init and
+             * Must be done AFTER clib4_init (which runs stdio_file_init and
              * sets up __fd[0..2]) so that __clib4 is the child's own context. */
             {
                 extern void import_pending_fds_for_process(struct _clib4 *__clib4, uint32 pid, uint32 ppid);
@@ -744,14 +815,14 @@ BPTR libClose(struct LibraryManagerInterface *Self) {
             SHOWMSG("Done. All external destructors called");
         }
 
-        /* Always call clib4 internal destructors (__DTOR_LIST__).
-         * These include stdlib_memory_exit (frees per-process memory mutex),
-         * stdio_exit, __pthread_exit, etc.
+        /* Always call clib4 internal cleanup functions, in the reverse
+         * order of clib4_init(). These include stdlib_memory_exit (frees
+         * per-process memory mutex), stdio_exit, __pthread_exit, etc.
          * call_main() only handles __EXT_DTOR_LIST__ (the exe's own dtors),
-         * not the library's internal __DTOR_LIST__. */
-        SHOWMSG("Calling clib4 internal dtors");
-        _end_ctors(__DTOR_LIST__);
-        SHOWMSG("Done. All clib4 destructors called");
+         * not the library's internal cleanup. */
+        SHOWMSG("Calling clib4 exit functions");
+        clib4_exit();
+        SHOWMSG("Done. All clib4 exit functions called");
 
         /* Now safe to restore task priority and deallocate resources */
         /* Restore the task priority. */

--- a/library/socket/init_exit.c
+++ b/library/socket/init_exit.c
@@ -62,7 +62,7 @@ STATIC struct Hook error_hook = {
     NULL
 };
 
-SOCKET_DESTRUCTOR(socket_exit) {
+void socket_exit(void) {
     ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 
@@ -96,7 +96,7 @@ SOCKET_DESTRUCTOR(socket_exit) {
     LEAVE();
 }
 
-SOCKET_CONSTRUCTOR(socket_init) {
+void socket_init(void) {
     struct TagItem tags[5];
     BOOL success = FALSE;
     LONG status;

--- a/library/stdio/file_init.c
+++ b/library/stdio/file_init.c
@@ -155,7 +155,7 @@ out:
     return (result);
 }
 
-FILE_CONSTRUCTOR(stdio_file_init) {
+void stdio_file_init(void) {
     APTR stdio_lock;
     APTR fd_lock;
     BPTR default_file;

--- a/library/stdio/init_exit.c
+++ b/library/stdio/init_exit.c
@@ -127,7 +127,7 @@ __close_all_files(struct _clib4 *__clib4) {
     LEAVE();
 }
 
-STDIO_DESTRUCTOR(stdio_exit) {
+void stdio_exit(void) {
     ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 
@@ -138,7 +138,7 @@ STDIO_DESTRUCTOR(stdio_exit) {
     LEAVE();
 }
 
-STDIO_CONSTRUCTOR(stdio_init) {
+void stdio_init(void) {
     const int num_standard_files = (STDERR_FILENO - STDIN_FILENO + 1);
     BOOL success = FALSE;
     struct _clib4 *__clib4 = __CLIB4;

--- a/library/stdlib/malloc.c
+++ b/library/stdlib/malloc.c
@@ -84,7 +84,7 @@ void __memory_unlock(struct _clib4 *__clib4) {
         MutexRelease(__clib4->memory_mutex);
 }
 
-STDLIB_DESTRUCTOR(stdlib_memory_exit) {
+void stdlib_memory_exit(void) {
     ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 
@@ -99,17 +99,18 @@ STDLIB_DESTRUCTOR(stdlib_memory_exit) {
     LEAVE();
 }
 
-/* Second constructor called by _init */
-STDLIB_CONSTRUCTOR(stdlib_memory_init) {
+/* Called by clib4_init() in libOpen, before any other initialization function */
+void stdlib_memory_init(void) {
     BOOL success = FALSE;
     struct _clib4 *__clib4 = __CLIB4;
     struct Clib4Resource *res;
 
     ENTER();
 
-    /* This constructor can run twice for statically linked programs (once
-     * from the library-internal ctor list in libOpen and once from the
-     * program's own ctor list in call_main), so it must be idempotent. */
+    /* This function can run twice for statically linked programs (once
+     * from clib4_init() in libOpen and once from the program's own ctor
+     * list in call_main for binaries built with an older clib4), so it
+     * must be idempotent. */
     if (__clib4->memory_mutex == NULL) {
         __clib4->memory_mutex = __create_mutex();
         if (__clib4->memory_mutex == NULL)

--- a/library/stdlib/setenv.c
+++ b/library/stdlib/setenv.c
@@ -19,7 +19,7 @@ struct LocalVariable {
 	char *lv_Name;
 };
 
-CLIB_DESTRUCTOR(__setenv_exit) {
+void __setenv_exit(void) {
 	ENTER();
 	struct _clib4 *__clib4 = __CLIB4;
 	/* Now for the local variables that may still be set. */

--- a/library/stdlib/stdlib_constructor.h
+++ b/library/stdlib/stdlib_constructor.h
@@ -5,135 +5,49 @@
 #ifndef _STDLIB_CONSTRUCTOR_H
 #define _STDLIB_CONSTRUCTOR_H
 
-#define NEW_CONSTRUCTOR_CALL
-
-/****************************************************************************/
-
-/* Constructor and destructor functions, as used by the library for data
-   initialization and cleanup. These particular functions are invoked by
-   the startup code before and after the main() function is/was called.
-   How this works is very compiler specific. We support three flavours
-   below. */
-
-/****************************************************************************/
-
-#ifdef NEW_CONSTRUCTOR_CALL
-#define CONSTRUCTOR(name, pri) \
-    static void __attribute__((used, constructor(pri))) name##_ctor(VOID); \
-    static void (*__##name##_ctor)(void) = name##_ctor; \
-    static void name##_ctor(void)
-
-#define DESTRUCTOR(name, pri) \
-    static void __attribute__((used, destructor(pri))) name##_dtor(VOID); \
-    static void (*__##name##_dtor)(void) = name##_dtor; \
-    static void name##_dtor(void)
-
-#define NSCONSTRUCTOR(name, pri) \
-    void __attribute__((used, constructor(pri))) name##_ctor(VOID); \
-    void (*__##name##_ctor)(void) = name##_ctor; \
-    void name##_ctor(void)
-
-#define NSDESTRUCTOR(name, pri) \
-    void __attribute__((used, destructor(pri))) name##_dtor(VOID); \
-    void (*__##name##_dtor)(void) = name##_dtor; \
-    void name##_dtor(void)
-
-#else
-
-#define CONSTRUCTOR(name,pri) \
-	STATIC VOID __attribute__((used)) name##_ctor(VOID); \
-	STATIC VOID (*__##name##_ctor)(VOID) __attribute__((used,section(".ctors._" #pri))) = name##_ctor; \
-	STATIC VOID name##_ctor(VOID)
-
-#define DESTRUCTOR(name,pri) \
-	STATIC VOID __attribute__((used)) name##_dtor(VOID); \
-	STATIC VOID (*__##name##_dtor)(VOID) __attribute__((used,section(".dtors._" #pri))) = name##_dtor; \
-	STATIC VOID name##_dtor(VOID)
-#endif
-
 #define CONSTRUCTOR_SUCCEED() \
 	return
 
 // This can cause problems on libraries because of exit. We should find a better way to do this
 #define CONSTRUCTOR_FAIL() \
 	exit(RETURN_FAIL)
-
+    
 /****************************************************************************/
 
-/* These macros are for declaring functions to serve as constructors or
-   destructors. In which order these should be invoked is defined by the
-   priority, which is a number in the range 0-999. User-supplied
-   constructor/destructor functions should have priority 0. That way,
-   the user-supplied constructors will be invoked after the library
-   constructors and the user-supplied destructors before the library
-   destructors. */
+/* Initialization functions, called in this exact order from clib4_init()
+   (shared_library/clib4.c, libOpen) */
 
-#ifdef NEW_CONSTRUCTOR_CALL
+void stdlib_memory_init(void);		/* STDLIB	- stdlib/malloc.c            */
+void stdio_init(void);				/* STDIO	- stdio/init_exit.c          */
+void stdio_file_init(void);		/* FILE		- stdio/file_init.c          */
+void math_init(void);				/* MATH		- math/init_exit.c           */
+void socket_init(void);			/* SOCKET	- socket/init_exit.c         */
+void locale_init(void);			/* CLIB		- locale/init_exit.c         */
+void usergroup_init(void);			/* CLIB		- usergroup/init_exit.c      */
+void timezone_init(void);			/* CLIB		- time/timezone_init_exit.c  */
+void unistd_init(void);			/* CLIB		- unistd/init_exit.c         */
+void timer_init(void);				/* CLIB		- unistd/timer.c             */
+void clock_init(void);				/* CLIB		- time/clock.c               */
+void dirent_init(void);			/* CLIB		- dirent/closedir.c          */
 
-#define START_CONSTRUCTOR 101
+/* Cleanup functions, called in this exact order from clib4_exit()
+   (shared_library/clib4.c, libClose): the reverse of the initialization
+   order above, plus the cleanup-only functions that have no matching
+   initialization function */
 
-#define STDLIB_CONSTRUCTOR(name)	CONSTRUCTOR(name,	START_CONSTRUCTOR)
-#define STDLIB_DESTRUCTOR(name)		DESTRUCTOR(name,	START_CONSTRUCTOR)
-
-#define STK_CONSTRUCTOR(name)		CONSTRUCTOR(name,	START_CONSTRUCTOR + 1)
-#define STK_DESTRUCTOR(name)		DESTRUCTOR(name,	START_CONSTRUCTOR + 1)
-
-#define STDIO_CONSTRUCTOR(name)		CONSTRUCTOR(name,	START_CONSTRUCTOR + 2)
-#define STDIO_DESTRUCTOR(name)		DESTRUCTOR(name,	START_CONSTRUCTOR + 2)
-
-#define FILE_CONSTRUCTOR(name)		CONSTRUCTOR(name,	START_CONSTRUCTOR + 3)
-#define FILE_DESTRUCTOR(name)		DESTRUCTOR(name,	START_CONSTRUCTOR + 3)
-
-#define MATH_CONSTRUCTOR(name)		CONSTRUCTOR(name,	START_CONSTRUCTOR + 4)
-#define MATH_DESTRUCTOR(name)		DESTRUCTOR(name,	START_CONSTRUCTOR + 4)
-
-#define SOCKET_CONSTRUCTOR(name)	CONSTRUCTOR(name,	START_CONSTRUCTOR + 5)
-#define SOCKET_DESTRUCTOR(name)		DESTRUCTOR(name,	START_CONSTRUCTOR + 5)
-
-#define ARG_CONSTRUCTOR(name)		CONSTRUCTOR(name,	START_CONSTRUCTOR + 6)
-#define ARG_DESTRUCTOR(name)		DESTRUCTOR(name,	START_CONSTRUCTOR + 6)
-
-#define CLIB_CONSTRUCTOR(name)		CONSTRUCTOR(name,	START_CONSTRUCTOR + 7)
-#define CLIB_DESTRUCTOR(name)		DESTRUCTOR(name,	START_CONSTRUCTOR + 7)
-
-#define PTHREAD_CONSTRUCTOR(name)	NSCONSTRUCTOR(name,	START_CONSTRUCTOR + 8)
-#define PTHREAD_DESTRUCTOR(name)	NSDESTRUCTOR(name,	START_CONSTRUCTOR + 8)
-
-#define PROFILE_CONSTRUCTOR(name)	CONSTRUCTOR(name,	START_CONSTRUCTOR + 9)
-#define PROFILE_DESTRUCTOR(name)	DESTRUCTOR(name,	START_CONSTRUCTOR + 9)
-
-#else
-#define STDLIB_CONSTRUCTOR(name)	CONSTRUCTOR(name,	10)
-#define STDLIB_DESTRUCTOR(name)		DESTRUCTOR(name,	10)
-
-#define STK_CONSTRUCTOR(name)		CONSTRUCTOR(name,	9)
-#define STK_DESTRUCTOR(name)		DESTRUCTOR(name,	9)
-
-#define STDIO_CONSTRUCTOR(name)		CONSTRUCTOR(name,	8)
-#define STDIO_DESTRUCTOR(name)		DESTRUCTOR(name,	8)
-
-#define FILE_CONSTRUCTOR(name)		CONSTRUCTOR(name,	7)
-#define FILE_DESTRUCTOR(name)		DESTRUCTOR(name,	7)
-
-#define MATH_CONSTRUCTOR(name)		CONSTRUCTOR(name,	6)
-#define MATH_DESTRUCTOR(name)		DESTRUCTOR(name,	6)
-
-#define SOCKET_CONSTRUCTOR(name)	CONSTRUCTOR(name,	5)
-#define SOCKET_DESTRUCTOR(name)		DESTRUCTOR(name,	5)
-
-#define ARG_CONSTRUCTOR(name)		CONSTRUCTOR(name,	4)
-#define ARG_DESTRUCTOR(name)		DESTRUCTOR(name,	4)
-
-#define CLIB_CONSTRUCTOR(name)		CONSTRUCTOR(name,	3)
-#define CLIB_DESTRUCTOR(name)		DESTRUCTOR(name,	3)
-
-#define PTHREAD_CONSTRUCTOR(name)	CONSTRUCTOR(name,	2)
-#define PTHREAD_DESTRUCTOR(name)	DESTRUCTOR(name,	2)
-
-#define PROFILE_CONSTRUCTOR(name)	CONSTRUCTOR(name,	1)
-#define PROFILE_DESTRUCTOR(name)	DESTRUCTOR(name,	1)
-#endif
-
+void dirent_exit(void);			/* CLIB		- dirent/closedir.c          */
+void timer_exit(void);				/* CLIB		- unistd/timer.c             */
+void unistd_exit(void);			/* CLIB		- unistd/init_exit.c         */
+void __wildcard_expand_exit(void);	/* CLIB		- unistd/wildcard_expand.c   */
+void __chdir_exit(void);			/* CLIB		- unistd/chdir_exit.c        */
+void __setenv_exit(void);			/* CLIB		- stdlib/setenv.c            */
+void dcngettext_exit(void);		/* CLIB		- locale/dcngettext.c        */
+void timezone_exit(void);			/* CLIB		- time/timezone_init_exit.c  */
+void usergroup_exit(void);			/* CLIB		- usergroup/init_exit.c      */
+void locale_exit(void);			/* CLIB		- locale/init_exit.c         */
+void socket_exit(void);			/* SOCKET	- socket/init_exit.c         */
+void stdio_exit(void);				/* STDIO	- stdio/init_exit.c          */
+void stdlib_memory_exit(void);		/* STDLIB	- stdlib/malloc.c            */
 
 /****************************************************************************/
 

--- a/library/time/clock.c
+++ b/library/time/clock.c
@@ -14,7 +14,7 @@
 #include "stdlib_constructor.h"
 #endif /* _STDLIB_CONSTRUCTOR_H */
 
-CLIB_CONSTRUCTOR(clock_init) {
+void clock_init(void) {
     ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 

--- a/library/time/timezone_init_exit.c
+++ b/library/time/timezone_init_exit.c
@@ -123,7 +123,7 @@ __timezone_unlock(void) {
         ReleaseSemaphore(__clib4->timezone_lock);
 }
 
-CLIB_DESTRUCTOR(timezone_exit) {
+void timezone_exit(void) {
     ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 
@@ -135,7 +135,7 @@ CLIB_DESTRUCTOR(timezone_exit) {
     LEAVE();
 }
 
-CLIB_CONSTRUCTOR(timezone_init) {
+void timezone_init(void) {
     ENTER();
 
     BOOL success = FALSE;

--- a/library/unistd/chdir_exit.c
+++ b/library/unistd/chdir_exit.c
@@ -10,7 +10,7 @@
 #include "stdlib_constructor.h"
 #endif /* _STDLIB_CONSTRUCTOR_H */
 
-CLIB_DESTRUCTOR(__chdir_exit) {
+void __chdir_exit(void) {
     ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 

--- a/library/unistd/init_exit.c
+++ b/library/unistd/init_exit.c
@@ -10,7 +10,7 @@
 #include "stdlib_constructor.h"
 #endif /* _STDLIB_CONSTRUCTOR_H */
 
-CLIB_CONSTRUCTOR(unistd_init) {
+void unistd_init(void) {
     ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 
@@ -22,7 +22,7 @@ CLIB_CONSTRUCTOR(unistd_init) {
     CONSTRUCTOR_SUCCEED();
 }
 
-CLIB_DESTRUCTOR(unistd_exit) {
+void unistd_exit(void) {
     ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 

--- a/library/unistd/timer.c
+++ b/library/unistd/timer.c
@@ -24,7 +24,7 @@
 
 #endif /* __NEW_TIMEVAL_DEFINITION_USED__ */
 
-CLIB_CONSTRUCTOR(timer_init) {
+void timer_init(void) {
     ENTER();
 
     BOOL success = FALSE;
@@ -82,7 +82,7 @@ out:
         CONSTRUCTOR_FAIL();
 }
 
-CLIB_DESTRUCTOR(timer_exit) {
+void timer_exit(void) {
     ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 

--- a/library/unistd/wildcard_expand.c
+++ b/library/unistd/wildcard_expand.c
@@ -58,7 +58,7 @@ out:
     return (result);
 }
 
-CLIB_DESTRUCTOR(__wildcard_expand_exit) {
+void __wildcard_expand_exit(void) {
     ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 

--- a/library/usergroup/init_exit.c
+++ b/library/usergroup/init_exit.c
@@ -15,7 +15,7 @@
 /* Pointer to errno, length == sizeof(long) */
 #define UGT_ERRNOLPTR 0x80000004
 
-CLIB_DESTRUCTOR(usergroup_exit) {
+void usergroup_exit(void) {
 	ENTER();
     struct _clib4 *__clib4 = __CLIB4;
 
@@ -32,7 +32,7 @@ CLIB_DESTRUCTOR(usergroup_exit) {
 	LEAVE();
 }
 
-CLIB_CONSTRUCTOR(usergroup_init) {
+void usergroup_init(void) {
 	struct TagItem tags[2];
 	BOOL success = FALSE;
     struct _clib4 *__clib4 = __CLIB4;


### PR DESCRIPTION
clib4's own initialization no longer relies on GCC constructor/destructor attributes with priorities walked via .ctors/.dtors: libOpen()/libClose() now call the init/exit functions directly in a fixed order through clib4_init()/clib4_exit(), so no other library with a same or lower constructor priority can run in between clib4's own initialization steps. The init/exit functions are plain functions named *_init/*_exit.

The satellite static libraries (libamiga, librt, libpthread) are not part of clib4.library and still register their init/exit functions via constructor/destructor attributes in the executable's ctor/dtor lists.