### PR TITLE
socket: match Linux semantics for non-blocking mode

### DIFF
--- a/library/socket/accept.c
+++ b/library/socket/accept.c
@@ -6,6 +6,8 @@
 #include "socket_headers.h"
 #endif /* _SOCKET_HEADERS_H */
 
+#include <sys/ioctl.h>
+
 int
 accept(int sockfd, struct sockaddr *cliaddr, socklen_t *addrlen) {
     APTR lock = NULL;
@@ -54,6 +56,33 @@ accept(int sockfd, struct sockaddr *cliaddr, socklen_t *addrlen) {
     if (new_socket_fd < 0) {
         SHOWMSG("could not accept connection");
         goto out;
+    }
+
+    /* Linux does NOT let the accepted socket inherit the listening socket's
+     * file status flags -- accept(2) says so explicitly: "the new socket
+     * returned by accept() does not inherit file status flags such as
+     * O_NONBLOCK and O_ASYNC from the listening socket".  The 4.4BSD stack
+     * underneath us does inherit them, so clear it here to match Linux.
+     *
+     * This is not merely cosmetic.  __initialize_fd() below always registers
+     * the new descriptor without FDF_NON_BLOCKING, and fcntl(F_SETFL) only
+     * issues file_action_set_blocking when the requested mode differs from
+     * that flag.  So an inherited non-blocking socket was unfixable from the
+     * outside: fcntl saw "already blocking, nothing to do" while the socket
+     * really was non-blocking, and the first read() came back EAGAIN.  That is
+     * exactly the sequence OpenJDK's java.net performs -- it deliberately puts
+     * listening sockets into non-blocking mode and relies on accept() handing
+     * back a blocking one -- and it made every accepted connection fail with
+     * "Resource temporarily unavailable".
+     *
+     * Forcing the mode keeps the descriptor's real state and the FDF_ flags
+     * consistent, which is what makes fcntl() usable on it afterwards.
+     */
+    {
+        int off = 0;
+
+        if (__IoctlSocket(new_socket_fd, FIONBIO, &off) < 0)
+            SHOWMSG("could not clear non-blocking mode on accepted socket");
     }
 
     /* OK, back to work: we'll need to manipulate the file

--- a/library/socket/socket.c
+++ b/library/socket/socket.c
@@ -6,6 +6,8 @@
 #include "socket_headers.h"
 #endif /* _SOCKET_HEADERS_H */
 
+#include <sys/ioctl.h>
+
 int
 socket(int domain, int type, int protocol) {
     APTR lock = NULL;
@@ -13,6 +15,7 @@ socket(int domain, int type, int protocol) {
     struct fd *fd;
     int fd_slot_number;
     LONG socket_fd;
+    int type_flags;
     struct _clib4 *__clib4 = __CLIB4;
 
     ENTER();
@@ -20,6 +23,21 @@ socket(int domain, int type, int protocol) {
     SHOWVALUE(domain);
     SHOWVALUE(type);
     SHOWVALUE(protocol);
+
+    /* Since Linux 2.6.27 the type argument may carry SOCK_NONBLOCK, saving the
+     * separate fcntl() round trip; it is the idiom most modern code uses.  We
+     * passed the whole type straight through to the 4.4BSD stack, which knows
+     * only SOCK_STREAM(1)/SOCK_DGRAM(2)/SOCK_RAW(3) -- SOCK_NONBLOCK is
+     * O_NONBLOCK, (1<<6), so socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0)
+     * arrived as type 65 and simply failed.  Strip the bit, remember it, and
+     * apply it below once the descriptor exists.
+     *
+     * SOCK_CLOEXEC is #defined to 0 in <sys/socket.h> here, so it cannot be
+     * distinguished yet; giving it a real value is a header change to make
+     * separately.
+     */
+    type_flags = type & SOCK_NONBLOCK;
+    type &= ~SOCK_NONBLOCK;
 
     __stdio_lock(__clib4);
 
@@ -63,6 +81,20 @@ socket(int domain, int type, int protocol) {
     __initialize_fd(fd, __socket_hook_entry, (BPTR) socket_fd, FDF_IN_USE | FDF_IS_SOCKET | FDF_READ | FDF_WRITE, lock);
 
     lock = NULL;
+
+    /* Apply the SOCK_NONBLOCK stripped above, recording FDF_NON_BLOCKING so
+     * the flag and the socket's real state agree -- fcntl(F_SETFL) trusts that
+     * flag to decide whether a change is needed at all.
+     */
+    if (type_flags & SOCK_NONBLOCK) {
+        int on = 1;
+
+        if (__IoctlSocket(socket_fd, FIONBIO, &on) < 0) {
+            SHOWMSG("could not set non-blocking mode on new socket");
+            goto out;
+        }
+        SET_FLAG(fd->fd_Flags, FDF_NON_BLOCKING);
+    }
 
     result = fd_slot_number;
 


### PR DESCRIPTION
Two places where a socket's real blocking state and the descriptor's FDF_NON_BLOCKING flag could disagree, leaving the descriptor in a state fcntl() could no longer repair.

accept(): Linux does not let the accepted socket inherit the listening socket's file status flags -- accept(2) states this explicitly for O_NONBLOCK and O_ASYNC.  The 4.4BSD stack underneath does inherit them, and __initialize_fd() always registers the new descriptor without FDF_NON_BLOCKING.  Since fcntl(F_SETFL) only issues file_action_set_blocking when the requested mode differs from that flag, an inherited non-blocking socket was unfixable from outside the library: fcntl saw "already blocking, nothing to do" while the socket really was non-blocking, and the first read() returned EAGAIN.

That is not a corner case.  It is what any program does that drives accept() from poll()/select(): put the listener in non-blocking mode, accept, then expect a blocking connection back (OpenJDK's java.net does exactly this, and every accepted connection failed with "Resource temporarily unavailable"). Clear the flag on the accepted socket so the descriptor's real state and its FDF_ flags agree.

socket(): since Linux 2.6.27 the type argument may carry SOCK_NONBLOCK, which is the idiom most modern code uses.  The whole type was passed through to the BSD stack, which knows only SOCK_STREAM(1)/SOCK_DGRAM(2)/SOCK_RAW(3); SOCK_NONBLOCK is O_NONBLOCK, (1<<6), so socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0) arrived as type 65 and failed.  Strip the bit before the call and apply it afterwards, recording FDF_NON_BLOCKING so the flag matches.

SOCK_CLOEXEC is still #defined to 0 in <sys/socket.h>, so it cannot be honoured yet; giving it a real value is a separate header change.  accept4() remains unimplemented.